### PR TITLE
[WIP] Official API for interacting with optimization results objects

### DIFF
--- a/src/Optim.jl
+++ b/src/Optim.jl
@@ -12,6 +12,21 @@ module Optim
            DifferentiableFunction,
            TwiceDifferentiableFunction
 
+    export method,
+           initial_state,
+           minimizer,
+           iterations,
+           iteration_converged,
+           x_converged,
+           xtol,
+           f_converged,
+           ftol,
+           gr_converged,
+           grtol,
+           history,
+           f_calls,
+           g_calls
+
     # Types
     include("types.jl")
 
@@ -67,6 +82,7 @@ module Optim
 
     # End-User Facing Wrapper Functions
     include("optimize.jl")
+    include("api.jl")
 
     # Examples for testing
     include(joinpath("problems", "unconstrained.jl"))

--- a/src/api.jl
+++ b/src/api.jl
@@ -1,0 +1,27 @@
+method(x::MultivariateOptimizationResults) = x.method
+initial_state(x::MultivariateOptimizationResults) = x.initial_x
+minimizer(x::MultivariateOptimizationResults) = x.minimum
+Base.minimum(x::MultivariateOptimizationResults) = x.f_minimum
+iterations(x::MultivariateOptimizationResults) = x.iterations
+iteration_converged(x::MultivariateOptimizationResults) = x.iteration_converged
+x_converged(x::MultivariateOptimizationResults) = x.x_converged
+xtol(x::MultivariateOptimizationResults) = x.xtol
+f_converged(x::MultivariateOptimizationResults) = x.f_converged
+ftol(x::MultivariateOptimizationResults) = x.ftol
+gr_converged(x::MultivariateOptimizationResults) = x.gr_converged
+grtol(x::MultivariateOptimizationResults) = x.grtol
+history(x::MultivariateOptimizationResults) = x.trace
+f_calls(x::MultivariateOptimizationResults) = x.f_calls
+g_calls(x::MultivariateOptimizationResults) = x.g_calls
+
+method(x::UnivariateOptimizationResults) = x.method
+lower_bound(x::UnivariateOptimizationResults) = x.initial_lower
+upper_bound(x::UnivariateOptimizationResults) = x.initial_upper
+minimizer(x::UnivariateOptimizationResults) = x.minimum
+Base.minimum(x::UnivariateOptimizationResults) = x.f_minimum
+iterations(x::UnivariateOptimizationResults) = x.iterations
+isconverged(x::UnivariateOptimizationResults) = x.converged
+rel_tol(x::UnivariateOptimizationResults) = x.rel_tol
+abs_tol(x::UnivariateOptimizationResults) = x.abs_tol
+history(x::UnivariateOptimizationResults) = x.trace
+f_calls(x::UnivariateOptimizationResults) = x.f_calls


### PR DESCRIPTION
This is a _very_ rough attempt to create an official API of functions that can be used to interact with the results objects returned by `optimize`. I do not like this API much, so I'm creating a WIP issue to elicit some bikeshedding.

Below I list all of the functions in the API while describing both their intent and my view about what's wrong with the names. Checked boxes are those which I think are settled for by existing arguments.

* [ ] `abs_tol`: What was the tolerance of a univariate optimization algorithm in absolute terms? I personally do not like this API and would prefer that we offer something more like `x_tol` (with relative and absolute versions). I'm not sure how hard it would be to change the code we're using, but I'd definitely prefer keeping the exact same interface for univariate and multivariate optimization.
* [ ] `Base.minimum`: The discovered minimum value of the function being minimized. This name matches precedence in the field, although it's a break from our previous names for the internal fields of the results objects.
* [ ] `f_calls`: How many times was the function being minimized called during the algorithm's execution?
* [ ] `f_converged`: Was the algorithm terminated because the values of the function stopped changing by `ftol`?
* [ ] `ftol`: How close must successive function values be to assert that the function converged?
* [ ] `g_calls`: How many times was the gradient of the function being minimized called during the algorithm's execution?
* [ ] `gr_converged`: Was the algorithm terminated because the max-norm of the gradient stopped changing by `grtol`?
* [ ] `grtol`: How close must successive max-norms of the gradient be to assert that the function converged?
* [ ] `history`: Obtain a tracing history of the algorithm's execution if this was requested during execution.
* [ ] `initial_state`: What the starting point of the algorithm?
* [ ] `isconverged`: Did the algorithm converge under any definition?
* [ ] `iteration_converged`: Did the algorithm terminate because it exceeded the maximum allowed number of iterations?
* [ ] `iterations`: How many iterations were completed when the algorithm was terminated?
* [ ] `lower_bound`: For univariate optimization problems, the user must provide a lower bound on the minimizer. This is that user-provided lower bound.
* [ ] `method`: Which algorithm was used to minimize the function?
* [ ] `minimizer`: What is the state at which the function's discovered minimum occurred?
* [ ] `rel_tol`: A relative tolerance on changes in the state of a univariate optimization algorithm. Would like to replace this one along with `abs_tol` or at least make them more separable.
* [ ] `upper_bound`:  For univariate optimization problems, the user must provide a upper bound on the minimizer. This is that user-provided upper bound.
* [ ] `x_converged`: Did the algorithm terminate because the state stopped changing by `xtol`?
* [ ] `xtol`: What is the max-norm of the difference between successive states at which the algorithm will terminate?

Closes #76.