### PR TITLE
Fix deprecated functions/syntax for Julia 0.4

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.2-
 Calculus
 DualNumbers
+Compat

--- a/src/Optim.jl
+++ b/src/Optim.jl
@@ -1,5 +1,6 @@
 module Optim
     using Calculus
+    using Compat
 
     import Base.dot,
            Base.length,

--- a/src/cg.jl
+++ b/src/cg.jl
@@ -146,7 +146,7 @@ function cg{T}(df::Union(DifferentiableFunction,
     # Store f(x) in f_x
     f_x = df.fg!(x, gr)
     @assert typeof(f_x) == T
-    f_x_previous = nan(T)
+    f_x_previous = convert(T, NaN)
     f_calls, g_calls = f_calls + 1, g_calls + 1
     copy!(gr_previous, gr)
 

--- a/src/fminbox.jl
+++ b/src/fminbox.jl
@@ -1,7 +1,7 @@
 # Attempt to compute a reasonable default mu: at the starting
 # position, the gradient of the input function should dominate the
 # gradient of the barrier.
-function initialize_mu{T}(gfunc::Array{T}, gbarrier::Array{T}; mu0::T = nan(T), mu0factor::T = 0.001)
+function initialize_mu{T}(gfunc::Array{T}, gbarrier::Array{T}; mu0::T = convert(T, NaN), mu0factor::T = 0.001)
     if isnan(mu0)
         gbarriernorm = sum(abs(gbarrier))
         if gbarriernorm > 0
@@ -26,7 +26,7 @@ function barrier_box{T}(x::Array{T}, g, l::Array{T}, u::Array{T})
         if isfinite(thisl)
             dx = x[i] - thisl
             if dx <= 0
-                return inf(T)
+                return convert(T, Inf)
             end
             v -= log(dx)
             if calc_grad
@@ -41,7 +41,7 @@ function barrier_box{T}(x::Array{T}, g, l::Array{T}, u::Array{T})
         if isfinite(thisu)
             dx = thisu - x[i]
             if dx <= 0
-                return inf(T)
+                return convert(T, Inf)
             end
             v -= log(dx)
             if calc_grad
@@ -76,7 +76,7 @@ function barrier_combined{T}(x::Array{T}, g, gfunc, gbarrier, val_each::Vector{T
 end
 
 function limits_box{T}(x::Array{T}, d::Array{T}, l::Array{T}, u::Array{T})
-    alphamax = inf(T)
+    alphamax = convert(T, Inf)
     for i = 1:length(x)
         if d[i] < 0
             alphamax = min(alphamax, ((l[i]-x[i])+eps(l[i]))/d[i])
@@ -118,7 +118,7 @@ function fminbox{T<:FloatingPoint}(df::DifferentiableFunction,
                     extended_trace::Bool = false,
                     linesearch!::Function = hz_linesearch!,
                     eta::Real = convert(T,0.4),
-                    mu0::T = nan(T),
+                    mu0::T = convert(T, NaN),
                     mufactor::T = convert(T, 0.001),
                     precondprep = (P, x, l, u, mu) -> precondprepbox(P, x, l, u, mu),
                     optimizer = cg)

--- a/src/levenberg_marquardt.jl
+++ b/src/levenberg_marquardt.jl
@@ -40,7 +40,7 @@ function levenberg_marquardt(f::Function, g::Function, x0; tolX=1e-8, tolG=1e-12
 	# Maintain a trace of the system.
 	tr = OptimizationTrace()
 	if show_trace
-		d = {"lambda" => lambda}
+		d = @compat Dict("lambda" => lambda)
 		os = OptimizationState(iterCt, sse(fcur), NaN, d)
 		push!(tr, os)
 		println(os)
@@ -89,7 +89,7 @@ function levenberg_marquardt(f::Function, g::Function, x0; tolX=1e-8, tolG=1e-12
 		# show state
 		if show_trace
 			gradnorm = norm(J'*fcur, Inf)
-			d = {"g(x)" => gradnorm, "dx" => delta_x, "lambda" => lambda}
+			d = @compat Dict("g(x)" => gradnorm, "dx" => delta_x, "lambda" => lambda)
 			os = OptimizationState(iterCt, sse(fcur), gradnorm, d)
 			push!(tr, os)
 			println(os)

--- a/src/linesearch/hz_linesearch.jl
+++ b/src/linesearch/hz_linesearch.jl
@@ -100,8 +100,8 @@ function alphatry{T}(alpha::T,
                      psi1::Real = convert(T,0.2),
                      psi2::Real = convert(T,2),
                      psi3::Real = convert(T,0.1),
-                     iterfinitemax::Integer = iceil(-log2(eps(T))),
-                     alphamax::Real = inf(T),
+                     iterfinitemax::Integer = ceil(Integer, -log2(eps(T))),
+                     alphamax::Real = convert(T, Inf),
                      display::Integer = 0)
     f_calls = 0
     g_calls = 0
@@ -177,13 +177,13 @@ function hz_linesearch!{T}(df::Union(DifferentiableFunction,
                            mayterminate::Bool,
                            delta::Real = DEFAULTDELTA,
                            sigma::Real = DEFAULTSIGMA,
-                           alphamax::Real = inf(T),
+                           alphamax::Real = convert(T,Inf),
                            rho::Real = convert(T,5),
                            epsilon::Real = convert(T,1e-6),
                            gamma::Real = convert(T,0.66),
                            linesearchmax::Integer = 50,
                            psi3::Real = convert(T,0.1),
-                           iterfinitemax::Integer = iceil(-log2(eps(T))),
+                           iterfinitemax::Integer = ceil(Integer, -log2(eps(T))),
                            display::Integer = 0)
     if display & LINESEARCH > 0
         println("New linesearch")
@@ -553,7 +553,7 @@ function bisect!{T}(df::Union(DifferentiableFunction,
                     display::Integer = 0)
     f_calls = 0
     g_calls = 0
-    gphi = nan(T)
+    gphi = convert(T, NaN)
     a = lsr.alpha[ia]
     b = lsr.alpha[ib]
     # Debugging (HZ, conditions shown following U3)
@@ -601,7 +601,7 @@ function linefunc!(df::Union(DifferentiableFunction,
     for i = 1:length(x)
         xtmp[i] = x[i] + alpha * s[i]
     end
-    gphi = nan(eltype(g))
+    gphi = convert(eltype(g), NaN)
     if calc_grad
         val = df.fg!(xtmp, g)
         f_calls += 1

--- a/src/nnls.jl
+++ b/src/nnls.jl
@@ -6,7 +6,7 @@ function nnls(A::AbstractMatrix, b::AbstractVector)
     x = fill(one(T), size(A, 2))
     # Set up constraints
     l = zeros(eltype(x), length(x))
-    u = fill(inf(eltype(x)), length(x))
+    u = fill(convert(eltype(x), Inf), length(x))
     # Perform the optimization    
     func = (x, g) -> nnlsobjective(x, g, A, b)
     df = DifferentiableFunction(x->func(x,nothing), func, func)

--- a/src/problems/unconstrained.jl
+++ b/src/problems/unconstrained.jl
@@ -40,7 +40,7 @@ examples["Exponential"] = OptimizationProblem("Exponential",
                                               exponential_gradient!,
                                               exponential_hessian!,
                                               [0.0, 0.0],
-                                              {[2.0, 3.0]},
+                                              [[2.0, 3.0]],
                                               true,
                                               true)
 
@@ -78,7 +78,7 @@ examples["Fletcher-Powell"] = OptimizationProblem("Fletcher-Powell",
                                                   fletcher_powell_gradient!,
                                                   fletcher_powell_hessian!,
                                                   [0.0, 0.0, 0.0],
-                                                  {[0.0, 0.0, 0.0]}, # TODO: Fix
+                                                  [[0.0, 0.0, 0.0]], # TODO: Fix
                                                   false,
                                                   false)
 
@@ -109,7 +109,7 @@ examples["Himmelbrau"] = OptimizationProblem("Himmelbrau",
                                              himmelbrau_gradient!,
                                              himmelbrau_hessian!,
                                              [0.0, 0.0],
-                                             {[1.0, 0.0]}, # TODO: Fix
+                                             [[1.0, 0.0]], # TODO: Fix
                                              true,
                                              false)
 ##########################################################################
@@ -138,7 +138,7 @@ examples["Hosaki"] = OptimizationProblem("Hosaki",
                                          hosaki_gradient!,
                                          hosaki_hessian!,
                                          [0.0, 0.0],
-                                         {[4.0, 2.0]},
+                                         [[4.0, 2.0]],
                                          false,
                                          false)
 
@@ -180,7 +180,7 @@ examples["Large Polynomial"] = OptimizationProblem("Large Polynomial",
                                                    large_polynomial_gradient!,
                                                    large_polynomial_hessian!,
                                                    zeros(250),
-                                                   {float([1:250])},
+                                                   [float([1:250])],
                                                    true,
                                                    true)
 
@@ -220,7 +220,7 @@ examples["Parabola"] = OptimizationProblem("Parabola",
                                            parabola_gradient!,
                                            parabola_hessian!,
                                            [0.0, 0.0, 0.0, 0.0, 0.0],
-                                           {[1.0, 2.0, 3.0, 5.0, 8.0]},
+                                           [[1.0, 2.0, 3.0, 5.0, 8.0]],
                                            true,
                                            true)
 
@@ -257,7 +257,7 @@ examples["Polynomial"] = OptimizationProblem("Polynomial",
                                              polynomial_gradient!,
                                              polynomial_hessian!,
                                              [0.0, 0.0, 0.0],
-                                             {[10.0, 7.0, 108.0]},
+                                             [[10.0, 7.0, 108.0]],
                                              true,
                                              true)
 
@@ -303,7 +303,7 @@ examples["Powell"] = OptimizationProblem("Powell",
                                          powell_gradient!,
                                          powell_hessian!,
                                          [3.0, -1.0, 0.0, 1.0],
-                                         {[0.0, 0.0, 0.0, 0.0]}, # TODO: Fix
+                                         [[0.0, 0.0, 0.0, 0.0]], # TODO: Fix
                                          true,
                                          true)
 
@@ -334,7 +334,7 @@ examples["Rosenbrock"] = OptimizationProblem("Rosenbrock",
                                              rosenbrock_gradient!,
                                              rosenbrock_hessian!,
                                              [0.0, 0.0],
-                                             {[1.0, 1.0]},
+                                             [[1.0, 1.0]],
                                              true,
                                              true)
 


### PR DESCRIPTION
Using Compat this time for dictionary constructions.
Tests pass for me sans warnings on the 0.3.4 release and the master.

[nan and inf deprecated](https://github.com/JuliaLang/julia/pull/8776)
[iceil merged into ceil](https://github.com/JuliaLang/julia/pull/9133)