### PR TITLE
Improve error messages in hz_linesearch

### DIFF
--- a/src/linesearch/hz_linesearch.jl
+++ b/src/linesearch/hz_linesearch.jl
@@ -420,8 +420,8 @@ function secant2!{T}(df::Union(DifferentiableFunction,
     b = lsr.alpha[ib]
     dphia = lsr.slope[ia]
     dphib = lsr.slope[ib]
-    @assert dphia < 0
-    @assert dphib >= 0
+    @assert dphia < 0 "dphia = $dphia < 0; gradient or Hessian may be incorrect"
+    @assert dphib >= 0 "dphib = $dphib >= 0; gradient or Hessian may be incorrect"
     c = secant(a, b, dphia, dphib)
     if display & SECANT2 > 0
         println("secant2: a = ", a, ", b = ", b, ", c = ", c)

--- a/src/linesearch/hz_linesearch.jl
+++ b/src/linesearch/hz_linesearch.jl
@@ -423,7 +423,7 @@ function secant2!{T}(df::Union(DifferentiableFunction,
     if !(dphia < 0 && dphib >= 0)
         throw(Error(string("Search direction is not a direction of descent; ",
                            "this error may indicate that user-provided derivatives are inaccurate. ",
-                           "(dphia = $dphia; dphib = $dphib)")))
+                           @sprintf "(dphia = %f; dphib = %f)" dphia dphib)))
     end
     c = secant(a, b, dphia, dphib)
     if display & SECANT2 > 0

--- a/src/linesearch/hz_linesearch.jl
+++ b/src/linesearch/hz_linesearch.jl
@@ -420,8 +420,11 @@ function secant2!{T}(df::Union(DifferentiableFunction,
     b = lsr.alpha[ib]
     dphia = lsr.slope[ia]
     dphib = lsr.slope[ib]
-    @assert dphia < 0 "dphia = $dphia < 0; gradient or Hessian may be incorrect"
-    @assert dphib >= 0 "dphib = $dphib >= 0; gradient or Hessian may be incorrect"
+    if !(dphia < 0 && dphib >= 0)
+        throw(Error(string("Search direction is not a direction of descent; ",
+                           "this error may indicate that user-provided derivatives are inaccurate. ",
+                           "(dphia = $dphia; dphib = $dphib)")))
+    end
     c = secant(a, b, dphia, dphib)
     if display & SECANT2 > 0
         println("secant2: a = ", a, ", b = ", b, ", c = ", c)


### PR DESCRIPTION
If an incorrect or absent gradient or Hessian is given, hz_linesearch
will sometimes error out with "assertion failed: dphia < 0." This commit
supplies a more informative error message suggesting that the user's
gradient or Hessian may be wrong.