### PR TITLE
fix traced function values of Nelder-Mead method

### DIFF
--- a/src/nelder_mead.jl
+++ b/src/nelder_mead.jl
@@ -157,6 +157,7 @@ function nelder_mead{T}(f::Function,
                             @inbounds p[j, i] = (p[j, i] + p_l[j]) / 2.0
                         end
                         @inbounds y[i] = f(p[:, i])
+                        f_calls += 1
                     end
                 else
                     @inbounds p_h[:] = p_star_star

--- a/src/nelder_mead.jl
+++ b/src/nelder_mead.jl
@@ -127,7 +127,7 @@ function nelder_mead{T}(f::Function,
             y_star_star = f(p_star_star)
             f_calls += 1
 
-            if y_star_star < y_l
+            if y_star_star < y_star
                 @inbounds p_h[:] = p_star_star
                 @inbounds p[:, h] = p_star_star
                 @inbounds y[h] = y_star_star

--- a/src/nelder_mead.jl
+++ b/src/nelder_mead.jl
@@ -1,5 +1,3 @@
-centroid(p::Matrix) = reshape(mean(p, 2), size(p, 1))
-
 function dominates(x::Vector, y::Vector)
     for i in 1:length(x)
         @inbounds if x[i] <= y[i]
@@ -181,12 +179,12 @@ function nelder_mead{T}(f::Function,
         end
     end
 
-    x = centroid(p)
+    y_l, l = findmin(y)
 
     return MultivariateOptimizationResults("Nelder-Mead",
                                            initial_x,
-                                           x,
-                                           float64(f(x)),
+                                           p[:, l],
+                                           float64(y_l),
                                            iteration,
                                            iteration == iterations,
                                            false,

--- a/src/nelder_mead.jl
+++ b/src/nelder_mead.jl
@@ -30,7 +30,7 @@ macro nmtrace()
             grnorm = NaN
             update!(tr,
                     iteration,
-                    f_x,
+                    minimum(y),
                     grnorm,
                     dt,
                     store_trace,
@@ -181,12 +181,12 @@ function nelder_mead{T}(f::Function,
         end
     end
 
-    minimum = centroid(p)
+    x = centroid(p)
 
     return MultivariateOptimizationResults("Nelder-Mead",
                                            initial_x,
-                                           minimum,
-                                           float64(f(minimum)),
+                                           x,
+                                           float64(f(x)),
                                            iteration,
                                            iteration == iterations,
                                            false,

--- a/src/nelder_mead.jl
+++ b/src/nelder_mead.jl
@@ -152,7 +152,7 @@ function nelder_mead{T}(f::Function,
                 f_calls += 1
 
                 if y_star_star > y_h
-                    for i = 1:n
+                    for i in 1:n
                         for j in 1:m
                             @inbounds p[j, i] = (p[j, i] + p_l[j]) / 2.0
                         end


### PR DESCRIPTION
Tracing of the Nelder-Mead method shows variance-like values among vertices of a simplex.
This may be an intended behavior but would be misleading when compared to other optimization methods.
Instead, this pull request traces the minimum value among vertices of a simplex, which slightly increases the computational cost but would be negligible in other operations.

