### PR TITLE
abstract DifferentiableFunction

### DIFF
--- a/src/cg.jl
+++ b/src/cg.jl
@@ -144,7 +144,7 @@ function cg{T}(df::Union(DifferentiableFunction,
     y = similar(x)
 
     # Store f(x) in f_x
-    f_x = df.fg!(x, gr)
+    f_x = evalfg!(df, x, gr)
     @assert typeof(f_x) == T
     f_x_previous = convert(T, NaN)
     f_calls, g_calls = f_calls + 1, g_calls + 1
@@ -230,7 +230,7 @@ function cg{T}(df::Union(DifferentiableFunction,
         copy!(gr_previous, gr)
 
         # Update the function value and gradient
-        f_x_previous, f_x = f_x, df.fg!(x, gr)
+        f_x_previous, f_x = f_x, evalfg!(df, x, gr)
         f_calls, g_calls = f_calls + 1, g_calls + 1
 
         x_converged,

--- a/src/linesearch/backtracking_linesearch.jl
+++ b/src/linesearch/backtracking_linesearch.jl
@@ -23,7 +23,7 @@ function backtracking_linesearch!{T}(d::Union(DifferentiableFunction,
     n = length(x)
 
     # Store f(x) in f_x
-    f_x = d.fg!(x, gr_scratch)
+    f_x = evalfg!(d, x, gr_scratch)
     f_calls += 1
     g_calls += 1
 
@@ -36,7 +36,7 @@ function backtracking_linesearch!{T}(d::Union(DifferentiableFunction,
     end
 
     # Backtrack until we satisfy sufficient decrease condition
-    f_x_scratch = d.f(x_scratch)
+    f_x_scratch = evalf(d, x_scratch)
     f_calls += 1
     while f_x_scratch > f_x + c1 * alpha * gxp
         # Increment the number of steps we've had to perform
@@ -56,7 +56,7 @@ function backtracking_linesearch!{T}(d::Union(DifferentiableFunction,
         end
 
         # Evaluate f(x) at proposed position
-        f_x_scratch = d.f(x_scratch)
+        f_x_scratch = evalf(d, x_scratch)
         f_calls += 1
     end
 

--- a/src/linesearch/hz_linesearch.jl
+++ b/src/linesearch/hz_linesearch.jl
@@ -101,14 +101,14 @@ function alphatry{T}(alpha::T,
     alphatest = min(alphatest, alphamax)
 
     # Use xtmp here
-    phitest = d.f(x + alphatest * s)
+    phitest = evalf(d, x + alphatest * s)
     f_calls += 1
 
     iterfinite = 1
     while !isfinite(phitest)
         alphatest = psi3 * alphatest
         # Use xtmp here
-        phitest = d.f(x + alphatest * s)
+        phitest = evalf(d, x + alphatest * s)
         f_calls += 1
         lsr.nfailures += 1
         iterfinite += 1
@@ -594,14 +594,14 @@ function linefunc!(df::Union(DifferentiableFunction,
     end
     gphi = convert(eltype(g), NaN)
     if calc_grad
-        val = df.fg!(xtmp, g)
+        val = evalfg!(df, xtmp, g)
         f_calls += 1
         g_calls += 1
         if isfinite(val)
             gphi = _dot(g, s)
         end
     else
-        val = df.f(xtmp)
+        val = evalf(df, xtmp)
         f_calls += 1
     end
     return val, gphi, f_calls, g_calls

--- a/src/linesearch/mt_linesearch.jl
+++ b/src/linesearch/mt_linesearch.jl
@@ -157,7 +157,7 @@ function mt_linesearch!{T}(fcn::Union(DifferentiableFunction,
    f_calls = 0
    g_calls = 0
 
-   f = fcn.fg!(x, g)
+   f = evalfg!(fcn, x, g)
    f_calls += 1
    g_calls += 1
 
@@ -252,7 +252,7 @@ function mt_linesearch!{T}(fcn::Union(DifferentiableFunction,
       for i in 1:n
          new_x[i] = x[i] + stp * s[i] # TODO: Use x_new here
       end
-      f = fcn.fg!(new_x, g)
+      f = evalfg!(fcn, new_x, g)
       f_calls += 1
       g_calls += 1
       nfev += 1 # This includes calls to f() and g!()

--- a/src/types.jl
+++ b/src/types.jl
@@ -53,18 +53,68 @@ type UnivariateOptimizationResults{T} <: OptimizationResults
     f_calls::Int
 end
 
-immutable DifferentiableFunction
+# Interface for evaluating the value and the gradient of
+# a differentiable function
+abstract DifferentiableFunction
+
+# Implementation of DifferentialFunction based on Function objects
+immutable SimpleDifferentiableFunction <: DifferentiableFunction
     f::Function
     g!::Function
     fg!::Function
 end
 
-immutable TwiceDifferentiableFunction
+evalf(df::SimpleDifferentiableFunction, x) = df.f(x)
+evalg!(df::SimpleDifferentiableFunction, x, grad) = df.g!(x, grad)
+evalfg!(df::SimpleDifferentiableFunction, x, grad) = df.fg!(x, grad)
+
+Base.convert(::Type{DifferentiableFunction}, f::Function, g!::Function, fg!::Function) = SimpleDifferentiableFunction(f, g!, fg!)
+
+# Callable wrapper of DifferentiableFunction
+# that evaluates the function properties specified by WHAT parameter
+immutable DifferentiableFunctionEval{WHAT, DF<:DifferentiableFunction}
+    df::DF
+end
+
+# "function"-like object that evaluates f(x)
+evalf_func{DF<:DifferentiableFunction}(df::DF) = DifferentiableFunctionEval{:F, DF}(df)
+# "function"-like object that evaluates the gradient of f(x)
+evalg!_func{DF<:DifferentiableFunction}(df::DF) = DifferentiableFunctionEval{:G!, DF}(df)
+# "function"-like object that evaluates the value and gradient of f(x)
+evalfg!_func{DF<:DifferentiableFunction}(df::DF) = DifferentiableFunctionEval{:FG!, DF}(df)
+
+Base.call(dfevalf::DifferentiableFunctionEval{:F}, x) = evalf(dfevalf.df, x)
+Base.call(dfevalf::DifferentiableFunctionEval{:G!}, x, grad) = evalfg!(dfevalf.df, x, grad)
+Base.call(dfevalf::DifferentiableFunctionEval{:FG!}, x, grad) = evalfg!(dfevalf.df, x, grad)
+
+# Interface for evaluating the value, gradient and Hessian of
+# a twice differentiable function
+abstract TwiceDifferentiableFunction <: DifferentiableFunction
+
+# Implementation of TwoceDifferentialFunction based on Function objects
+immutable SimpleTwiceDifferentiableFunction <: TwiceDifferentiableFunction
     f::Function
     g!::Function
     fg!::Function
     h!::Function
 end
+
+Base.convert(::Type{TwiceDifferentiableFunction}, f::Function, g!::Function, fg!::Function, h!::Function) = SimpleTwiceDifferentiableFunction(f, g!, fg!, h!)
+
+evalf(df::SimpleTwiceDifferentiableFunction, x) = df.f(x)
+evalg!(df::SimpleTwiceDifferentiableFunction, x, grad) = df.g!(x, grad)
+evalfg!(df::SimpleTwiceDifferentiableFunction, x, grad) = df.fg!(x, grad)
+evalh!(df::SimpleTwiceDifferentiableFunction, x, hessian) = df.h!(x, hessian)
+
+# Callable wrapper of TwiceDifferentiableFunction
+# that evaluates the function properties specified by WHAT parameter
+# (only :H as all other properties are already handled by DifferentiableFunctionEval)
+immutable TwiceDifferentiableFunctionEval{WHAT, DF<:TwiceDifferentiableFunction}
+    df::DF
+end
+
+evalh!_func{DF<:TwiceDifferentiableFunction}(df::DF) = TwiceDifferentiableFunctionEval{:H!, DF}(df)
+Base.call(dfevalf::TwiceDifferentiableFunctionEval{:H!}, x, hessian) = evalh!(dfevalf.df, x, hessian)
 
 function Base.show(io::IO, t::OptimizationState)
     @printf io "%6d   %14e   %14e\n" t.iteration t.value t.gradnorm

--- a/src/types.jl
+++ b/src/types.jl
@@ -70,6 +70,7 @@ evalfg!(df::SimpleDifferentiableFunction, x, grad) = df.fg!(x, grad)
 
 Base.convert(::Type{DifferentiableFunction}, f::Function, g!::Function, fg!::Function) = SimpleDifferentiableFunction(f, g!, fg!)
 
+if VERSION >= v"0.4-"
 # Callable wrapper of DifferentiableFunction
 # that evaluates the function properties specified by WHAT parameter
 immutable DifferentiableFunctionEval{WHAT, DF<:DifferentiableFunction}
@@ -86,6 +87,7 @@ evalfg!_func{DF<:DifferentiableFunction}(df::DF) = DifferentiableFunctionEval{:F
 Base.call(dfevalf::DifferentiableFunctionEval{:F}, x) = evalf(dfevalf.df, x)
 Base.call(dfevalf::DifferentiableFunctionEval{:G!}, x, grad) = evalfg!(dfevalf.df, x, grad)
 Base.call(dfevalf::DifferentiableFunctionEval{:FG!}, x, grad) = evalfg!(dfevalf.df, x, grad)
+end
 
 # Interface for evaluating the value, gradient and Hessian of
 # a twice differentiable function
@@ -106,6 +108,7 @@ evalg!(df::SimpleTwiceDifferentiableFunction, x, grad) = df.g!(x, grad)
 evalfg!(df::SimpleTwiceDifferentiableFunction, x, grad) = df.fg!(x, grad)
 evalh!(df::SimpleTwiceDifferentiableFunction, x, hessian) = df.h!(x, hessian)
 
+if VERSION >= v"0.4-"
 # Callable wrapper of TwiceDifferentiableFunction
 # that evaluates the function properties specified by WHAT parameter
 # (only :H as all other properties are already handled by DifferentiableFunctionEval)
@@ -115,6 +118,7 @@ end
 
 evalh!_func{DF<:TwiceDifferentiableFunction}(df::DF) = TwiceDifferentiableFunctionEval{:H!, DF}(df)
 Base.call(dfevalf::TwiceDifferentiableFunctionEval{:H!}, x, hessian) = evalh!(dfevalf.df, x, hessian)
+end
 
 function Base.show(io::IO, t::OptimizationState)
     @printf io "%6d   %14e   %14e\n" t.iteration t.value t.gradnorm


### PR DESCRIPTION
This is related to #53, #94, #102 etc.
With the current implementation of ```DifferentiableFunction``` it's not very convenient to implement functions that require external data for evaluation. It always ends up writing something like
```julia
df = DifferentiableFunction(x -> real_func(x, data) .... )
```
before every optimizer invocation.

This PR turns ```DifferentiableFunction``` into an abstract type, and calls like ```df.f(x)``` are supposed to be replaced by ```evalf(df, x)```.
The old ```DifferentiableFunction``` is renamed into ```SimpleDifferentiableFunction```. Since ```SimpleDifferentiableFunction``` is used when one wants to convert 3 functions into ```DifferentiableFunction``` object, the current Optim code does not require any modifications.