### PR TITLE
implemented callback functions

### DIFF
--- a/src/Optim.jl
+++ b/src/Optim.jl
@@ -12,7 +12,9 @@ module Optim
 
     export optimize,
            DifferentiableFunction,
-           TwiceDifferentiableFunction
+           TwiceDifferentiableFunction,
+           OptimizationState,
+           OptimizationTrace
 
     # Utils
     include("utils.jl")

--- a/src/accelerated_gradient_descent.jl
+++ b/src/accelerated_gradient_descent.jl
@@ -21,7 +21,9 @@ macro agdtrace()
                     grnorm,
                     dt,
                     store_trace,
-                    show_trace)
+                    show_trace,
+                    show_every,
+                    callback)
         end
     end
 end
@@ -35,6 +37,8 @@ function accelerated_gradient_descent{T}(d::DifferentiableFunction,
                                          store_trace::Bool = false,
                                          show_trace::Bool = false,
                                          extended_trace::Bool = false,
+                                         callback = nothing,
+                                         show_every = 1,
                                          linesearch!::Function = hz_linesearch!)
     # Maintain current state in x and previous state in x_previous
     x, x_previous = copy(initial_x), copy(initial_x)
@@ -75,7 +79,7 @@ function accelerated_gradient_descent{T}(d::DifferentiableFunction,
 
     # Trace the history of states visited
     tr = OptimizationTrace()
-    tracing = store_trace || show_trace || extended_trace
+    tracing = store_trace || show_trace || extended_trace || callback != nothing
     @agdtrace
 
     # Assess types of convergence

--- a/src/bfgs.jl
+++ b/src/bfgs.jl
@@ -18,7 +18,9 @@ macro bfgstrace()
                     grnorm,
                     dt,
                     store_trace,
-                    show_trace)
+                    show_trace,
+                    show_every,
+                    callback)
         end
     end
 end
@@ -34,6 +36,8 @@ function bfgs{T}(d::Union(DifferentiableFunction,
                  store_trace::Bool = false,
                  show_trace::Bool = false,
                  extended_trace::Bool = false,
+                 callback = nothing,
+                 show_every = 1,
                  linesearch!::Function = hz_linesearch!)
 
     # Maintain current state in x and previous state in x_previous
@@ -85,7 +89,7 @@ function bfgs{T}(d::Union(DifferentiableFunction,
 
     # Trace the history of states visited
     tr = OptimizationTrace()
-    tracing = store_trace || show_trace || extended_trace
+    tracing = store_trace || show_trace || extended_trace || callback != nothing
     @bfgstrace
 
     # Assess multiple types of convergence

--- a/src/brent.jl
+++ b/src/brent.jl
@@ -13,7 +13,9 @@ macro brenttrace()
                     NaN,
                     dt,
                     store_trace,
-                    show_trace)
+                    show_trace,
+                    show_every,
+                    callback)
         end
     end
 end
@@ -24,6 +26,8 @@ function brent{T <: FloatingPoint}(f::Function, x_lower::T, x_upper::T;
                                    iterations::Integer = 1_000,
                                    store_trace::Bool = false,
                                    show_trace::Bool = false,
+                                   callback = nothing,
+                                   show_every = 1,
                                    extended_trace::Bool = false)
 
     if !(x_lower < x_upper)
@@ -33,13 +37,13 @@ function brent{T <: FloatingPoint}(f::Function, x_lower::T, x_upper::T;
     # Save for later
     initial_lower = x_lower
     initial_upper = x_upper
-    
+
     const golden_ratio::T = 0.5 * (3.0 - sqrt(5.0))
 
     x_minimum = x_lower + golden_ratio*(x_upper-x_lower)
     f_minimum = f(x_minimum)
     f_calls = 1 # Number of calls to f
-    
+
     step = zero(T)
     step_old = zero(T)
 
@@ -48,13 +52,13 @@ function brent{T <: FloatingPoint}(f::Function, x_lower::T, x_upper::T;
 
     f_minimum_old = f_minimum
     f_minimum_old_old = f_minimum
-    
+
     it = 0
     converged = false
 
     # Trace the history of states visited
     tr = OptimizationTrace()
-    tracing = store_trace || show_trace || extended_trace
+    tracing = store_trace || show_trace || extended_trace || callback != nothing
     @brenttrace
 
     while it < iterations
@@ -72,12 +76,12 @@ function brent{T <: FloatingPoint}(f::Function, x_lower::T, x_upper::T;
         end
 
         it += 1
-        
+
         if abs(step_old) > tolx
             # Compute parabola interpolation
             # x_minimum + p/q is the optimum of the parabola
             # Also, q is guaranteed to be positive
-            
+
             r = (x_minimum - x_minimum_old) * (f_minimum - f_minimum_old_old)
             q = (x_minimum - x_minimum_old_old) * (f_minimum - f_minimum_old)
             p = (x_minimum - x_minimum_old_old) * q - (x_minimum - x_minimum_old) * r

--- a/src/cg.jl
+++ b/src/cg.jl
@@ -96,7 +96,9 @@ macro cgtrace()
                     grnorm,
                     dt,
                     store_trace,
-                    show_trace)
+                    show_trace,
+                    show_every,
+                    callback)
         end
     end
 end
@@ -111,6 +113,8 @@ function cg{T}(df::Union(DifferentiableFunction,
                store_trace::Bool = false,
                show_trace::Bool = false,
                extended_trace::Bool = false,
+               callback = nothing,
+               show_every = 1,
                linesearch!::Function = hz_linesearch!,
                eta::Real = convert(T,0.4),
                P::Any = nothing,
@@ -161,7 +165,7 @@ function cg{T}(df::Union(DifferentiableFunction,
 
     # Trace the history of states visited
     tr = OptimizationTrace()
-    tracing = store_trace || show_trace || extended_trace
+    tracing = store_trace || show_trace || extended_trace || callback != nothing
     @cgtrace
 
     # Output messages

--- a/src/fminbox.jl
+++ b/src/fminbox.jl
@@ -116,6 +116,8 @@ function fminbox{T<:FloatingPoint}(df::DifferentiableFunction,
                     store_trace::Bool = false,
                     show_trace::Bool = false,
                     extended_trace::Bool = false,
+                    callback = nothing,
+                    show_every = 1,
                     linesearch!::Function = hz_linesearch!,
                     eta::Real = convert(T,0.4),
                     mu0::T = convert(T, NaN),
@@ -152,7 +154,7 @@ function fminbox{T<:FloatingPoint}(df::DifferentiableFunction,
     end
 
     g = similar(x)
-    valboth = Array(T, 2)    
+    valboth = Array(T, 2)
     fval_all = Array(Vector{T}, 0)
     fcount_all = 0
     xold = similar(x)

--- a/src/golden_section.jl
+++ b/src/golden_section.jl
@@ -13,7 +13,9 @@ macro goldensectiontrace()
                     NaN,
                     dt,
                     store_trace,
-                    show_trace)
+                    show_trace,
+                    show_every,
+                    callback)
         end
     end
 end
@@ -24,15 +26,17 @@ function golden_section{T <: FloatingPoint}(f::Function, x_lower::T, x_upper::T;
                                             iterations::Integer = 1_000,
                                             store_trace::Bool = false,
                                             show_trace::Bool = false,
+                                            callback = nothing,
+                                            show_every = 1,
                                             extended_trace::Bool = false)
     if !(x_lower < x_upper)
         error("x_lower must be less than x_upper")
     end
-    
+
     # Save for later
     initial_lower = x_lower
     initial_upper = x_upper
-    
+
     const golden_ratio::T = 0.5 * (3.0 - sqrt(5.0))
 
     x_minimum = x_lower + golden_ratio*(x_upper-x_lower)
@@ -44,9 +48,9 @@ function golden_section{T <: FloatingPoint}(f::Function, x_lower::T, x_upper::T;
 
     # Trace the history of states visited
     tr = OptimizationTrace()
-    tracing = store_trace || show_trace || extended_trace
+    tracing = store_trace || show_trace || extended_trace || callback != nothing
     @goldensectiontrace
-    
+
     while it < iterations
 
         tolx = rel_tol * abs(x_minimum) + abs_tol
@@ -59,7 +63,7 @@ function golden_section{T <: FloatingPoint}(f::Function, x_lower::T, x_upper::T;
         end
 
         it += 1
-        
+
         if x_upper - x_minimum > x_minimum - x_lower
             x_new = x_minimum + golden_ratio*(x_upper - x_minimum)
             f_new = f(x_new)

--- a/src/gradient_descent.jl
+++ b/src/gradient_descent.jl
@@ -13,7 +13,9 @@ macro gdtrace()
                     grnorm,
                     dt,
                     store_trace,
-                    show_trace)
+                    show_trace,
+                    show_every,
+                    callback)
         end
     end
 end
@@ -28,6 +30,8 @@ function gradient_descent{T}(d::Union(DifferentiableFunction,
                              store_trace::Bool = false,
                              show_trace::Bool = false,
                              extended_trace::Bool = false,
+                             callback = nothing,
+                             show_every = 1,
                              linesearch!::Function = hz_linesearch!)
 
     # Maintain current state in x and previous state in x_previous
@@ -67,7 +71,7 @@ function gradient_descent{T}(d::Union(DifferentiableFunction,
 
     # Trace the history of states visited
     tr = OptimizationTrace()
-    tracing = store_trace || show_trace || extended_trace
+    tracing = store_trace || show_trace || extended_trace || callback != nothing
     @gdtrace
 
     # Assess multiple types of convergence

--- a/src/l_bfgs.jl
+++ b/src/l_bfgs.jl
@@ -75,7 +75,9 @@ macro lbfgstrace()
                     grnorm,
                     dt,
                     store_trace,
-                    show_trace)
+                    show_trace,
+                    show_every,
+                    callback)
         end
     end
 end
@@ -91,6 +93,8 @@ function l_bfgs{T}(d::Union(DifferentiableFunction,
                    store_trace::Bool = false,
                    show_trace::Bool = false,
                    extended_trace::Bool = false,
+                   callback = nothing,
+                   show_every = 1,
                    linesearch!::Function = hz_linesearch!)
 
     # Maintain current state in x and previous state in x_previous
@@ -140,7 +144,7 @@ function l_bfgs{T}(d::Union(DifferentiableFunction,
 
     # Trace the history of states visited
     tr = OptimizationTrace()
-    tracing = store_trace || show_trace || extended_trace
+    tracing = store_trace || show_trace || extended_trace || callback != nothing
     @lbfgstrace
 
     # Assess multiple types of convergence

--- a/src/levenberg_marquardt.jl
+++ b/src/levenberg_marquardt.jl
@@ -1,7 +1,14 @@
 # sse(x) gives the L2 norm of x
 sse(x) = (x'*x)[1]
 
-function levenberg_marquardt(f::Function, g::Function, x0; tolX=1e-8, tolG=1e-12, maxIter=100, lambda=100.0, show_trace=false)
+function levenberg_marquardt(f::Function, g::Function, x0;
+                             tolX=1e-8,
+                             tolG=1e-12,
+                             maxIter=100,
+                             lambda=100.0,
+                             show_trace=false,
+                             callback = nothing,
+                             show_every = 1)
 	# finds argmin sum(f(x).^2) using the Levenberg-Marquardt algorithm
 	#          x
 	# The function f should take an input vector of length n and return an output vector of length m
@@ -37,7 +44,7 @@ function levenberg_marquardt(f::Function, g::Function, x0; tolX=1e-8, tolG=1e-12
 	fcur = f(x)
 	f_calls += 1
 	residual = sse(fcur)
-	
+
 	# Maintain a trace of the system.
 	tr = OptimizationTrace()
 	if show_trace
@@ -108,7 +115,7 @@ function levenberg_marquardt(f::Function, g::Function, x0; tolX=1e-8, tolG=1e-12
 		elseif norm(delta_x) < tolX*(tolX + norm(x))
 			x_converged = true
 		end
-		converged = g_converged | x_converged   
+		converged = g_converged | x_converged
 	end
 
 	MultivariateOptimizationResults("Levenberg-Marquardt", x0, x, sse(fcur), iterCt, !converged, x_converged, 0.0, false, 0.0, g_converged, tolG, tr, f_calls, g_calls)

--- a/src/momentum_gradient_descent.jl
+++ b/src/momentum_gradient_descent.jl
@@ -16,7 +16,9 @@ macro mgdtrace()
                     grnorm,
                     dt,
                     store_trace,
-                    show_trace)
+                    show_trace,
+                    show_every,
+                    callback)
         end
     end
 end
@@ -31,6 +33,8 @@ function momentum_gradient_descent{T}(d::DifferentiableFunction,
                                       store_trace::Bool = false,
                                       show_trace::Bool = false,
                                       extended_trace::Bool = false,
+                                      callback = nothing,
+                                      show_every = 1,
                                       linesearch!::Function = hz_linesearch!)
     # Maintain current state in x and previous state in x_previous
     x, x_previous = copy(initial_x), copy(initial_x)
@@ -68,7 +72,7 @@ function momentum_gradient_descent{T}(d::DifferentiableFunction,
 
     # Trace the history of states visited
     tr = OptimizationTrace()
-    tracing = store_trace || show_trace || extended_trace
+    tracing = store_trace || show_trace || extended_trace || callback != nothing
     @mgdtrace
 
     # Assess multiple types of convergence

--- a/src/nelder_mead.jl
+++ b/src/nelder_mead.jl
@@ -34,7 +34,9 @@ macro nmtrace()
                     grnorm,
                     dt,
                     store_trace,
-                    show_trace)
+                    show_trace,
+                    show_every,
+                    callback)
         end
     end
 end
@@ -49,6 +51,8 @@ function nelder_mead{T}(f::Function,
                         iterations::Integer = 1_000,
                         store_trace::Bool = false,
                         show_trace::Bool = false,
+                        callback = nothing,
+                        show_every = 1,
                         extended_trace::Bool = false)
     # Set up a simplex of points around starting value
     m = length(initial_x)
@@ -78,7 +82,7 @@ function nelder_mead{T}(f::Function,
 
     # Maintain a trace
     tr = OptimizationTrace()
-    tracing = show_trace || store_trace || extended_trace
+    tracing = show_trace || store_trace || extended_trace || callback != nothing
     @nmtrace
 
     # Cache p_bar, y_bar, p_star and p_star_star

--- a/src/newton.jl
+++ b/src/newton.jl
@@ -14,7 +14,9 @@ macro newtontrace()
                     grnorm,
                     dt,
                     store_trace,
-                    show_trace)
+                    show_trace,
+                    show_every,
+                    callback)
         end
     end
 end
@@ -28,6 +30,8 @@ function newton{T}(d::TwiceDifferentiableFunction,
                    store_trace::Bool = false,
                    show_trace::Bool = false,
                    extended_trace::Bool = false,
+                   callback = nothing,
+                   show_every = 1,
                    linesearch!::Function = hz_linesearch!)
 
     # Maintain current state in x and previous state in x_previous
@@ -71,7 +75,7 @@ function newton{T}(d::TwiceDifferentiableFunction,
 
     # Trace the history of states visited
     tr = OptimizationTrace()
-    tracing = store_trace || show_trace || extended_trace
+    tracing = store_trace || show_trace || extended_trace || callback != nothing
     @newtontrace
 
     # Assess multiple types of convergence

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -11,7 +11,7 @@ function optimize(d::TwiceDifferentiableFunction,
                   linesearch!::Function = hz_linesearch!,
                   bfgs_initial_invH = nothing)
     if extended_trace
-        store_trace = true
+        show_trace = true
     end
     if show_trace
         @printf "Iter     Function value   Gradient norm \n"
@@ -52,7 +52,7 @@ function optimize(d::TwiceDifferentiableFunction,
     elseif method == :bfgs
         if bfgs_initial_invH == nothing
             bfgs_initial_invH = eye(length(initial_x))
-        end        
+        end
         bfgs(d,
              initial_x,
              xtol = xtol,
@@ -145,7 +145,7 @@ function optimize(d::DifferentiableFunction,
     elseif method == :bfgs
         if bfgs_initial_invH == nothing
             bfgs_initial_invH = eye(length(initial_x))
-        end        
+        end
         bfgs(d,
              initial_x,
              xtol = xtol,
@@ -259,7 +259,7 @@ function optimize(f::Function,
     elseif method == :bfgs
         if bfgs_initial_invH == nothing
             bfgs_initial_invH = eye(length(initial_x))
-        end        
+        end
         d = DifferentiableFunction(f, g!)
         bfgs(d,
              initial_x,
@@ -362,7 +362,7 @@ function optimize(f::Function,
     elseif method == :bfgs
         if bfgs_initial_invH == nothing
             bfgs_initial_invH = eye(length(initial_x))
-        end        
+        end
         d = DifferentiableFunction(f, g!)
         bfgs(d,
              initial_x,
@@ -469,7 +469,7 @@ function optimize(f::Function,
     elseif method == :bfgs
         if bfgs_initial_invH == nothing
             bfgs_initial_invH = eye(length(initial_x))
-        end        
+        end
         bfgs(d,
              initial_x,
              xtol = xtol,

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -8,9 +8,12 @@ function optimize(d::TwiceDifferentiableFunction,
                   store_trace::Bool = false,
                   show_trace::Bool = false,
                   extended_trace::Bool = false,
+                  callback = nothing,
+                  show_every = 1,
                   linesearch!::Function = hz_linesearch!,
                   bfgs_initial_invH = nothing)
-    if extended_trace
+    show_every = show_every > 0 ? show_every: 1
+    if extended_trace && callback == nothing
         show_trace = true
     end
     if show_trace
@@ -26,6 +29,8 @@ function optimize(d::TwiceDifferentiableFunction,
                          store_trace = store_trace,
                          show_trace = show_trace,
                          extended_trace = extended_trace,
+                         show_every = show_every,
+                         callback = callback,
                          linesearch! = linesearch!)
     elseif method == :momentum_gradient_descent
         momentum_gradient_descent(d,
@@ -37,6 +42,8 @@ function optimize(d::TwiceDifferentiableFunction,
                                   store_trace = store_trace,
                                   show_trace = show_trace,
                                   extended_trace = extended_trace,
+                                  show_every = show_every,
+                                  callback = callback,
                                   linesearch! = linesearch!)
     elseif method == :cg
         cg(d,
@@ -48,6 +55,8 @@ function optimize(d::TwiceDifferentiableFunction,
            store_trace = store_trace,
            show_trace = show_trace,
            extended_trace = extended_trace,
+           show_every = show_every,
+           callback = callback,
            linesearch! = linesearch!)
     elseif method == :bfgs
         if bfgs_initial_invH == nothing
@@ -63,6 +72,8 @@ function optimize(d::TwiceDifferentiableFunction,
              show_trace = show_trace,
              extended_trace = extended_trace,
              linesearch! = linesearch!,
+             show_every = show_every,
+             callback = callback,
              initial_invH = bfgs_initial_invH)
     elseif method == :l_bfgs
         l_bfgs(d,
@@ -74,6 +85,8 @@ function optimize(d::TwiceDifferentiableFunction,
                store_trace = store_trace,
                show_trace = show_trace,
                extended_trace = extended_trace,
+               show_every = show_every,
+               callback = callback,
                linesearch! = linesearch!)
     elseif method == :newton
         newton(d,
@@ -85,6 +98,8 @@ function optimize(d::TwiceDifferentiableFunction,
                store_trace = store_trace,
                show_trace = show_trace,
                extended_trace = extended_trace,
+               show_every = show_every,
+               callback = callback,
                linesearch! = linesearch!)
     else
         throw(ArgumentError("Unknown method $method"))
@@ -101,9 +116,12 @@ function optimize(d::DifferentiableFunction,
                   store_trace::Bool = false,
                   show_trace::Bool = false,
                   extended_trace::Bool = false,
+                  callback = nothing,
+                  show_every = 1,
                   linesearch!::Function = hz_linesearch!,
                   bfgs_initial_invH = nothing)
-    if extended_trace
+    show_every = show_every > 0 ? show_every: 1
+    if extended_trace && callback == nothing
         show_trace = true
     end
     if show_trace
@@ -119,6 +137,8 @@ function optimize(d::DifferentiableFunction,
                          store_trace = store_trace,
                          show_trace = show_trace,
                          extended_trace = extended_trace,
+                         show_every = show_every,
+                         callback = callback,
                          linesearch! = linesearch!)
     elseif method == :momentum_gradient_descent
         momentum_gradient_descent(d,
@@ -130,6 +150,8 @@ function optimize(d::DifferentiableFunction,
                                   store_trace = store_trace,
                                   show_trace = show_trace,
                                   extended_trace = extended_trace,
+                                  show_every = show_every,
+                                  callback = callback,
                                   linesearch! = linesearch!)
     elseif method == :cg
         cg(d,
@@ -141,6 +163,8 @@ function optimize(d::DifferentiableFunction,
            store_trace = store_trace,
            show_trace = show_trace,
            extended_trace = extended_trace,
+           show_every = show_every,
+           callback = callback,
            linesearch! = linesearch!)
     elseif method == :bfgs
         if bfgs_initial_invH == nothing
@@ -156,6 +180,8 @@ function optimize(d::DifferentiableFunction,
              show_trace = show_trace,
              extended_trace = extended_trace,
              linesearch! = linesearch!,
+             show_every = show_every,
+             callback = callback,
              initial_invH = bfgs_initial_invH)
     elseif method == :l_bfgs
         l_bfgs(d,
@@ -167,6 +193,8 @@ function optimize(d::DifferentiableFunction,
                store_trace = store_trace,
                show_trace = show_trace,
                extended_trace = extended_trace,
+               show_every = show_every,
+               callback = callback,
                linesearch! = linesearch!)
     else
         throw(ArgumentError("Unknown method $method"))
@@ -185,9 +213,12 @@ function optimize(f::Function,
                   store_trace::Bool = false,
                   show_trace::Bool = false,
                   extended_trace::Bool = false,
+                  callback = nothing,
+                  show_every = 1,
                   linesearch!::Function = hz_linesearch!,
                   bfgs_initial_invH = nothing)
-    if extended_trace
+    show_every = show_every > 0 ? show_every: 1
+    if extended_trace && callback == nothing
         show_trace = true
     end
     if show_trace
@@ -200,6 +231,8 @@ function optimize(f::Function,
                     iterations = iterations,
                     store_trace = store_trace,
                     show_trace = show_trace,
+                    show_every = show_every,
+                    callback = callback,
                     extended_trace = extended_trace)
     elseif method == :simulated_annealing
         simulated_annealing(f,
@@ -207,6 +240,8 @@ function optimize(f::Function,
                             iterations = iterations,
                             store_trace = store_trace,
                             show_trace = show_trace,
+                            show_every = show_every,
+                            callback = callback,
                             extended_trace = extended_trace)
     elseif method == :gradient_descent
         d = DifferentiableFunction(f, g!)
@@ -219,6 +254,8 @@ function optimize(f::Function,
                          store_trace = store_trace,
                          show_trace = show_trace,
                          extended_trace = extended_trace,
+                         show_every = show_every,
+                         callback = callback,
                          linesearch! = linesearch!)
     elseif method == :momentum_gradient_descent
         d = DifferentiableFunction(f, g!)
@@ -231,6 +268,8 @@ function optimize(f::Function,
                                   store_trace = store_trace,
                                   show_trace = show_trace,
                                   extended_trace = extended_trace,
+                                  show_every = show_every,
+                                  callback = callback,
                                   linesearch! = linesearch!)
     elseif method == :cg
         d = DifferentiableFunction(f, g!)
@@ -243,6 +282,8 @@ function optimize(f::Function,
            store_trace = store_trace,
            show_trace = show_trace,
            extended_trace = extended_trace,
+           show_every = show_every,
+           callback = callback,
            linesearch! = linesearch!)
     elseif method == :newton
         d = TwiceDifferentiableFunction(f, g!, h!)
@@ -255,6 +296,8 @@ function optimize(f::Function,
                store_trace = store_trace,
                show_trace = show_trace,
                extended_trace = extended_trace,
+               show_every = show_every,
+               callback = callback,
                linesearch! = linesearch!)
     elseif method == :bfgs
         if bfgs_initial_invH == nothing
@@ -270,6 +313,8 @@ function optimize(f::Function,
              store_trace = store_trace,
              show_trace = show_trace,
              extended_trace = extended_trace,
+             show_every = show_every,
+             callback = callback,
              linesearch! = linesearch!,
              initial_invH = bfgs_initial_invH)
     elseif method == :l_bfgs
@@ -283,6 +328,8 @@ function optimize(f::Function,
                store_trace = store_trace,
                show_trace = show_trace,
                extended_trace = extended_trace,
+               show_every = show_every,
+               callback = callback,
                linesearch! = linesearch!)
     else
         throw(ArgumentError("Unknown method $method"))
@@ -300,9 +347,12 @@ function optimize(f::Function,
                   store_trace::Bool = false,
                   show_trace::Bool = false,
                   extended_trace::Bool = false,
+                  callback = nothing,
+                  show_every = 1,
                   linesearch!::Function = hz_linesearch!,
                   bfgs_initial_invH = nothing)
-    if extended_trace
+    show_every = show_every > 0 ? show_every: 1
+    if extended_trace && callback == nothing
         show_trace = true
     end
     if show_trace
@@ -315,6 +365,8 @@ function optimize(f::Function,
                     iterations = iterations,
                     store_trace = store_trace,
                     show_trace = show_trace,
+                    show_every = show_every,
+                    callback = callback,
                     extended_trace = extended_trace)
     elseif method == :simulated_annealing
         simulated_annealing(f,
@@ -322,6 +374,8 @@ function optimize(f::Function,
                             iterations = iterations,
                             store_trace = store_trace,
                             show_trace = show_trace,
+                            show_every = show_every,
+                            callback = callback,
                             extended_trace = extended_trace)
     elseif method == :gradient_descent
         d = DifferentiableFunction(f, g!)
@@ -334,6 +388,8 @@ function optimize(f::Function,
                          store_trace = store_trace,
                          show_trace = show_trace,
                          extended_trace = extended_trace,
+                         show_every = show_every,
+                         callback = callback,
                          linesearch! = linesearch!)
     elseif method == :momentum_gradient_descent
         d = DifferentiableFunction(f, g!)
@@ -346,6 +402,8 @@ function optimize(f::Function,
                                   store_trace = store_trace,
                                   show_trace = show_trace,
                                   extended_trace = extended_trace,
+                                  show_every = show_every,
+                                  callback = callback,
                                   linesearch! = linesearch!)
     elseif method == :cg
         d = DifferentiableFunction(f, g!)
@@ -358,6 +416,8 @@ function optimize(f::Function,
            store_trace = store_trace,
            show_trace = show_trace,
            extended_trace = extended_trace,
+           show_every = show_every,
+           callback = callback,
            linesearch! = linesearch!)
     elseif method == :bfgs
         if bfgs_initial_invH == nothing
@@ -373,6 +433,8 @@ function optimize(f::Function,
              store_trace = store_trace,
              show_trace = show_trace,
              extended_trace = extended_trace,
+             show_every = show_every,
+             callback = callback,
              linesearch! = linesearch!,
              initial_invH = bfgs_initial_invH)
     elseif method == :l_bfgs
@@ -386,6 +448,8 @@ function optimize(f::Function,
                store_trace = store_trace,
                show_trace = show_trace,
                extended_trace = extended_trace,
+               show_every = show_every,
+               callback = callback,
                linesearch! = linesearch!)
     else
         throw(ArgumentError("Unknown method $method"))
@@ -402,10 +466,13 @@ function optimize(f::Function,
                   store_trace::Bool = false,
                   show_trace::Bool = false,
                   extended_trace::Bool = false,
+                  callback = nothing,
+                  show_every = 1,
                   linesearch!::Function = hz_linesearch!,
                   autodiff::Bool = false,
                   bfgs_initial_invH = nothing)
-    if extended_trace
+    show_every = show_every > 0 ? show_every: 1
+    if extended_trace && callback == nothing
         show_trace = true
     end
     if show_trace
@@ -418,6 +485,8 @@ function optimize(f::Function,
                     iterations = iterations,
                     store_trace = store_trace,
                     show_trace = show_trace,
+                    show_every = show_every,
+                    callback = callback,
                     extended_trace = extended_trace)
     elseif method == :simulated_annealing
         return simulated_annealing(f,
@@ -425,6 +494,8 @@ function optimize(f::Function,
                             iterations = iterations,
                             store_trace = store_trace,
                             show_trace = show_trace,
+                            show_every = show_every,
+                            callback = callback,
                             extended_trace = extended_trace)
     end
     # otherwise we need a gradient:
@@ -443,6 +514,8 @@ function optimize(f::Function,
                          store_trace = store_trace,
                          show_trace = show_trace,
                          extended_trace = extended_trace,
+                         show_every = show_every,
+                         callback = callback,
                          linesearch! = linesearch!)
     elseif method == :momentum_gradient_descent
         momentum_gradient_descent(d,
@@ -454,6 +527,8 @@ function optimize(f::Function,
                                   store_trace = store_trace,
                                   show_trace = show_trace,
                                   extended_trace = extended_trace,
+                                  show_every = show_every,
+                                  callback = callback,
                                   linesearch! = linesearch!)
     elseif method == :cg
         cg(d,
@@ -465,6 +540,8 @@ function optimize(f::Function,
            store_trace = store_trace,
            show_trace = show_trace,
            extended_trace = extended_trace,
+           show_every = show_every,
+           callback = callback,
            linesearch! = linesearch!)
     elseif method == :bfgs
         if bfgs_initial_invH == nothing
@@ -479,6 +556,8 @@ function optimize(f::Function,
              store_trace = store_trace,
              show_trace = show_trace,
              extended_trace = extended_trace,
+             show_every = show_every,
+             callback = callback,
              linesearch! = linesearch!,
              initial_invH = bfgs_initial_invH)
     elseif method == :l_bfgs
@@ -491,6 +570,8 @@ function optimize(f::Function,
                store_trace = store_trace,
                show_trace = show_trace,
                extended_trace = extended_trace,
+               show_every = show_every,
+               callback = callback,
                linesearch! = linesearch!)
     else
         throw(ArgumentError("Unknown method $method"))
@@ -506,8 +587,11 @@ function optimize{T <: FloatingPoint}(f::Function,
                                       iterations::Integer = 1_000,
                                       store_trace::Bool = false,
                                       show_trace::Bool = false,
+                                      callback = nothing,
+                                      show_every = 1,
                                       extended_trace::Bool = false)
-    if extended_trace
+    show_every = show_every > 0 ? show_every: 1
+    if extended_trace && callback == nothing
         show_trace = true
     end
     if show_trace
@@ -520,6 +604,8 @@ function optimize{T <: FloatingPoint}(f::Function,
               iterations = iterations,
               store_trace = store_trace,
               show_trace = show_trace,
+              show_every = show_every,
+              callback = callback,
               extended_trace = extended_trace)
     elseif method == :golden_section
         golden_section(f, @compat(Float64(lower)), @compat(Float64(upper));
@@ -528,6 +614,8 @@ function optimize{T <: FloatingPoint}(f::Function,
                        iterations = iterations,
                        store_trace = store_trace,
                        show_trace = show_trace,
+                       show_every = show_every,
+                       callback = callback,
                        extended_trace = extended_trace)
     else
         throw(ArgumentError("Unknown method $method"))

--- a/src/simulated_annealing.jl
+++ b/src/simulated_annealing.jl
@@ -24,7 +24,9 @@ macro satrace()
                     grnorm,
                     dt,
                     store_trace,
-                    show_trace)
+                    show_trace,
+                    show_every,
+                    callback)
         end
     end
 end
@@ -37,6 +39,8 @@ function simulated_annealing{T}(cost::Function,
                                 iterations::Integer = 100_000,
                                 store_trace::Bool = false,
                                 show_trace::Bool = false,
+                                callback = nothing,
+                                show_every = 1,
                                 extended_trace::Bool = false)
     # Maintain current and proposed state
     x, x_proposal = copy(initial_x), copy(initial_x)
@@ -60,7 +64,7 @@ function simulated_annealing{T}(cost::Function,
 
     # Trace the history of states visited
     tr = OptimizationTrace()
-    tracing = store_trace || show_trace || extended_trace
+    tracing = store_trace || show_trace || extended_trace || callback != nothing
     @satrace
 
     # We always perform a fixed number of iterations

--- a/src/utilities/update.jl
+++ b/src/utilities/update.jl
@@ -4,13 +4,24 @@ function update!(tr::OptimizationTrace,
                  grnorm::Real,
                  dt::Dict,
                  store_trace::Bool,
-                 show_trace::Bool)
+                 show_trace::Bool,
+                 show_every::Int = 1,
+                 callback = nothing)
     os = OptimizationState(iteration, f_x, grnorm, dt)
     if store_trace
         push!(tr, os)
     end
     if show_trace
-        show(os)
+        if iteration % show_every == 0
+            show(os)
+        end
+    end
+    if callback != nothing && (iteration % show_every == 0)
+        if store_trace
+            callback(tr)
+        else
+            callback(os)
+        end
     end
     return
 end

--- a/test/callbacks.jl
+++ b/test/callbacks.jl
@@ -1,31 +1,3 @@
-function rosenbrock{T}(x::Vector{T})
-    o = one(T)
-    c = convert(T,100)
-    return (o - x[1])^2 + c * (x[2] - x[1]^2)^2
-end
-
-function rosenbrock_gradient!{T}(x::Vector{T}, storage::Vector{T})
-    o = one(T)
-    c = convert(T,100)
-    storage[1] = (-2*o) * (o - x[1]) - (4*c) * (x[2] - x[1]^2) * x[1]
-    storage[2] = (2*c) * (x[2] - x[1]^2)
-end
-
-function rosenbrock_hessian!{T}(x::Vector{T}, storage::Matrix{T})
-    o = one(T)
-    c = convert(T,100)
-    f = 4*c
-    storage[1, 1] = (2*o) - f * x[2] + 3 * f * x[1]^2
-    storage[1, 2] = -f * x[1]
-    storage[2, 1] = -f * x[1]
-    storage[2, 2] = 2*c
-end
-
-d2 = DifferentiableFunction(rosenbrock,
-                            rosenbrock_gradient!)
-d3 = TwiceDifferentiableFunction(rosenbrock,
-                                 rosenbrock_gradient!,
-                                 rosenbrock_hessian!)
 
 function cb(tr::OptimizationTrace)
     @test tr.states[end].iteration % 3 == 0
@@ -57,9 +29,7 @@ end
 for method in (:bfgs,
                :cg,
                :gradient_descent,
-               :momentum_gradient_descent,
-#                :accelerated_gradient_descent,
-               :l_bfgs)
+               :momentum_gradient_descent)
     ot_run = false
     function cb(tr::OptimizationTrace)
         @test tr.states[end].iteration % 3 == 0

--- a/test/callbacks.jl
+++ b/test/callbacks.jl
@@ -1,0 +1,96 @@
+function rosenbrock{T}(x::Vector{T})
+    o = one(T)
+    c = convert(T,100)
+    return (o - x[1])^2 + c * (x[2] - x[1]^2)^2
+end
+
+function rosenbrock_gradient!{T}(x::Vector{T}, storage::Vector{T})
+    o = one(T)
+    c = convert(T,100)
+    storage[1] = (-2*o) * (o - x[1]) - (4*c) * (x[2] - x[1]^2) * x[1]
+    storage[2] = (2*c) * (x[2] - x[1]^2)
+end
+
+function rosenbrock_hessian!{T}(x::Vector{T}, storage::Matrix{T})
+    o = one(T)
+    c = convert(T,100)
+    f = 4*c
+    storage[1, 1] = (2*o) - f * x[2] + 3 * f * x[1]^2
+    storage[1, 2] = -f * x[1]
+    storage[2, 1] = -f * x[1]
+    storage[2, 2] = 2*c
+end
+
+d2 = DifferentiableFunction(rosenbrock,
+                            rosenbrock_gradient!)
+d3 = TwiceDifferentiableFunction(rosenbrock,
+                                 rosenbrock_gradient!,
+                                 rosenbrock_hessian!)
+
+function cb(tr::OptimizationTrace)
+    @test tr.states[end].iteration % 3 == 0
+end
+
+function cb(os::OptimizationState)
+    @test os.iteration % 3 == 0
+end
+
+for method in (:nelder_mead,
+               :simulated_annealing)
+    ot_run = false
+    function cb(tr::OptimizationTrace)
+        @test tr.states[end].iteration % 3 == 0
+        ot_run = true
+    end
+    optimize(rosenbrock, [0.0,0,.0], method = method, callback = cb, show_every=3, store_trace=true)
+    @test ot_run == true
+
+    os_run = false
+    function cb(os::OptimizationState)
+        @test os.iteration % 3 == 0
+        os_run = true
+    end
+    optimize(rosenbrock, [0.0,0,.0], method = method, callback = cb, show_every=3)
+    @test os_run == true
+end
+
+for method in (:bfgs,
+               :cg,
+               :gradient_descent,
+               :momentum_gradient_descent,
+#                :accelerated_gradient_descent,
+               :l_bfgs)
+    ot_run = false
+    function cb(tr::OptimizationTrace)
+        @test tr.states[end].iteration % 3 == 0
+        ot_run = true
+    end
+    optimize(d2, [0.0,0,.0], method = method, callback = cb, show_every=3, store_trace=true)
+    @test ot_run == true
+
+    os_run = false
+    function cb(os::OptimizationState)
+        @test os.iteration % 3 == 0
+        os_run = true
+    end
+    optimize(d2, [0.0,0,.0], method = method, callback = cb, show_every=3)
+    @test os_run == true
+end
+
+for method in (:newton,)
+    ot_run = false
+    function cb(tr::OptimizationTrace)
+        @test tr.states[end].iteration % 3 == 0
+        ot_run = true
+    end
+    optimize(d3, [0.0,0.0], method = method, callback = cb, show_every=3, store_trace=true)
+    @test ot_run == true
+
+    os_run = false
+    function cb(os::OptimizationState)
+        @test os.iteration % 3 == 0
+        os_run = true
+    end
+    optimize(d3, [0.0,0.0], method = method, callback = cb, show_every=3)
+    @test os_run == true
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,7 +21,8 @@ my_tests = ["bfgs.jl",
             "brent.jl",
             "type_stability.jl",
             "array.jl",
-            "constrained.jl"
+            "constrained.jl",
+            "callbacks.jl"
            ]
 
 println("Running tests:")


### PR DESCRIPTION
This is the pull request discussed in #130. 

It allows for having callback functions without breaking the existing interface

First of all it introduced the `show_every` param (defaults to 1) which controls for how regularly traces are shown and callbacks are called.

`show_trace` is unaffected except the `show_every` influence and one detail: If a callback is given then setting `extended_trace` to true will not automatically set `show_trace` to true as well. This is such that you can have a callback that has access to the extended stuff without having to have the console spam of `show_trace`. Using the interface as it was before this PR yields same results as before.

Callbacks are implemented for all models but `fminbox` and `levenberg_marquar` since they are special in the show_trace regard

Here is an example for using callbacks
```Julia
function cb(os::OptimizationState)
    # do something with state
end
res = optimize(f, [0.0, 0.0], method = :gradient_descent, callback=cb, show_every=50)
```

Or even with the history
```Julia
function cb(tr::OptimizationTrace)
    # do something with trace
end
res = optimize(f, [0.0, 0.0], method = :gradient_descent, callback=cb, show_every=50, store_trace=true)
```

I added tests as well. Tested on 0.3.11 and 0.4.0-dev+6698

Let me know what you think