### PR TITLE
changes in levenberg_marquardt

### DIFF
--- a/src/levenberg_marquardt.jl
+++ b/src/levenberg_marquardt.jl
@@ -1,14 +1,6 @@
-# sse(x) gives the L2 norm of x
-sse(x) = (x'*x)[1]
-
-function levenberg_marquardt(f::Function, g::Function, x0;
-                             tolX=1e-8,
-                             tolG=1e-12,
-                             maxIter=100,
-                             lambda=100.0,
-                             show_trace=false,
-                             callback = nothing,
-                             show_every = 1)
+function levenberg_marquardt(f::Function, g::Function, x0; 
+	tolX::Real = 1e-8, tolG::Real = 1e-12, maxIter::Integer = 100,
+	lambda::Real = 10.0, show_trace::Bool = false)
 	# finds argmin sum(f(x).^2) using the Levenberg-Marquardt algorithm
 	#          x
 	# The function f should take an input vector of length n and return an output vector of length m
@@ -29,7 +21,9 @@ function levenberg_marquardt(f::Function, g::Function, x0;
 	const MAX_LAMBDA = 1e16 # minimum trust region radius
 	const MIN_LAMBDA = 1e-16 # maximum trust region radius
 	const MIN_STEP_QUALITY = 1e-3
+	const GOOD_STEP_QUALITY = 0.75
 	const MIN_DIAGONAL = 1e-6 # lower bound on values of diagonal matrix used to regularize the trust region step
+
 
 	converged = false
 	x_converged = false
@@ -43,13 +37,13 @@ function levenberg_marquardt(f::Function, g::Function, x0;
 
 	fcur = f(x)
 	f_calls += 1
-	residual = sse(fcur)
-
+	residual = sumabs2(fcur)
+	
 	# Maintain a trace of the system.
 	tr = OptimizationTrace()
 	if show_trace
 		d = @compat Dict("lambda" => lambda)
-		os = OptimizationState(iterCt, sse(fcur), NaN, d)
+		os = OptimizationState(iterCt, sumabs2(fcur), NaN, d)
 		push!(tr, os)
 		println(os)
 	end
@@ -63,14 +57,19 @@ function levenberg_marquardt(f::Function, g::Function, x0;
 		# we want to solve:
 		#    argmin 0.5*||J(x)*delta_x + f(x)||^2 + lambda*||diagm(J'*J)*delta_x||^2
 		# Solving for the minimum gives:
-		#    (J'*J + lambda*DtD) * delta_x == -J^T * f(x), where DtD = diagm(sum(J.^2,1))
-		# Where we have used the equivalence: diagm(J'*J) = diagm(sum(J.^2, 1))
+		#    (J'*J + lambda*diagm(DtD)) * delta_x == -J^T * f(x), where DtD = sumabs2(J,1)
+		# Where we have used the equivalence: diagm(J'*J) = diagm(sumabs2(J,1))
 		# It is additionally useful to bound the elements of DtD below to help
 		# prevent "parameter evaporation".
-		DtD = diagm(Float64[max(x, MIN_DIAGONAL) for x in sum(J.^2,1)])
-		delta_x = ( J'*J + sqrt(lambda)*DtD ) \ ( -J'*fcur )
+		DtD = vec(sumabs2(J, 1))
+		for i in 1:length(DtD)
+			if DtD[i] <= MIN_DIAGONAL
+				DtD[i] = MIN_DIAGONAL
+			end
+		end
+		delta_x = ( J'*J + lambda * diagm(DtD) ) \ ( -J'*fcur )
 		# if the linear assumption is valid, our new residual should be:
-		predicted_residual = sse(J*delta_x + fcur)
+		predicted_residual = sumabs2(J*delta_x + fcur)
 		# check for numerical problems in solving for delta_x by ensuring that the predicted residual is smaller
 		# than the current residual
 		if predicted_residual > residual + 2max(eps(predicted_residual),eps(residual))
@@ -81,16 +80,17 @@ function levenberg_marquardt(f::Function, g::Function, x0;
 		# try the step and compute its quality
 		trial_f = f(x + delta_x)
 		f_calls += 1
-		trial_residual = sse(trial_f)
+		trial_residual = sumabs2(trial_f)
 		# step quality = residual change / predicted residual change
 		rho = (trial_residual - residual) / (predicted_residual - residual)
-
 		if rho > MIN_STEP_QUALITY
 			x += delta_x
 			fcur = trial_f
 			residual = trial_residual
-			# increase trust region radius
-			lambda = max(0.1*lambda, MIN_LAMBDA)
+			if rho > GOOD_STEP_QUALITY
+				# increase trust region radius
+				lambda = max(0.1*lambda, MIN_LAMBDA)
+			end
 			need_jacobian = true
 		else
 			# decrease trust region radius
@@ -102,7 +102,7 @@ function levenberg_marquardt(f::Function, g::Function, x0;
 		if show_trace
 			gradnorm = norm(J'*fcur, Inf)
 			d = @compat Dict("g(x)" => gradnorm, "dx" => delta_x, "lambda" => lambda)
-			os = OptimizationState(iterCt, sse(fcur), gradnorm, d)
+			os = OptimizationState(iterCt, sumabs2(fcur), gradnorm, d)
 			push!(tr, os)
 			println(os)
 		end
@@ -115,8 +115,8 @@ function levenberg_marquardt(f::Function, g::Function, x0;
 		elseif norm(delta_x) < tolX*(tolX + norm(x))
 			x_converged = true
 		end
-		converged = g_converged | x_converged
+		converged = g_converged | x_converged   
 	end
 
-	MultivariateOptimizationResults("Levenberg-Marquardt", x0, x, sse(fcur), iterCt, !converged, x_converged, 0.0, false, 0.0, g_converged, tolG, tr, f_calls, g_calls)
+	MultivariateOptimizationResults("Levenberg-Marquardt", x0, x, sumabs2(fcur), iterCt, !converged, x_converged, 0.0, false, 0.0, g_converged, tolG, tr, f_calls, g_calls)
 end


### PR DESCRIPTION
Three changes
- sse is replaced by sumabs2
- sqrt(lambda) is replaced by lambda^2. I think it's a typo in the original implementation.
- lambda is diminished only if rho is close to one. This seems to be the standard for levenberg_marquardt
