### PR TITLE
Fix the trace printing (#147)

### DIFF
--- a/src/nelder_mead.jl
+++ b/src/nelder_mead.jl
@@ -30,8 +30,8 @@ macro nmtrace()
             grnorm = NaN
             update!(tr,
                     iteration,
-                    f_x,
-                    grnorm,
+                    Base.minimum(y), # best point in the simplex
+                    f_x, # f_x is used more like a grnorm for nelder_mead
                     dt,
                     store_trace,
                     show_trace,


### PR DESCRIPTION
f_x is not the objective value in nelder_mead but closer to the
gradient. So this reports a sensible objective value and uses f_x for
the gradient printing.