### PR TITLE
Fix remaining call to _dot

### DIFF
--- a/src/l_bfgs.jl
+++ b/src/l_bfgs.jl
@@ -167,7 +167,7 @@ function l_bfgs{T}(d::Union{DifferentiableFunction,
             @simd for i in 1:n
                 @inbounds s[i] = -gr[i]
             end
-            dphi0 = _dot(gr, s)
+            dphi0 = vecdot(gr, s)
         end
 
         clear!(lsr)


### PR DESCRIPTION
A call to the removed `_dot` method was left in the L-BFGS code. This fixes it.