### PR TITLE
Modified Newton using PositiveFactorizations

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.4
 Calculus
 DualNumbers 0.2
+PositiveFactorizations

--- a/src/Optim.jl
+++ b/src/Optim.jl
@@ -2,6 +2,7 @@ VERSION >= v"0.4.0-dev+6521" && __precompile__(true)
 
 module Optim
     using Calculus
+    using PositiveFactorizations
     using Compat
 
     import Base.length,

--- a/src/newton.jl
+++ b/src/newton.jl
@@ -95,9 +95,13 @@ function optimize{T}(d::TwiceDifferentiableFunction,
         # Increment the number of steps we've had to perform
         iteration += 1
 
-        # Search direction is always the negative gradient divided by H
-        # TODO: Do this calculation in place
-        @inbounds s[:] = -(H \ gr)
+        # Search direction is always the negative gradient divided by
+        # a matrix encoding the absolute values of the curvatures
+        # represented by H. It deviates from the usual "add a scaled
+        # identity matrix" version of the modified Newton method. More
+        # information can be found in the discussion at issue #153.
+        F, Hd = ldltfact!(Positive, H)
+        s[:] = -(F\gr)
 
         # Refresh the line search cache
         dphi0 = vecdot(gr, s)

--- a/test/newton.jl
+++ b/test/newton.jl
@@ -55,3 +55,10 @@ for (name, prob) in Optim.UnconstrainedProblems.examples
 		@assert norm(Optim.minimizer(res) - prob.solutions) < 1e-2
 	end
 end
+
+let
+    prob=Optim.UnconstrainedProblems.examples["Himmelblau"]
+    ddf = TwiceDifferentiableFunction(prob.f, prob.g!, prob.h!)
+    res = optimize(ddf, [0., 0.], Newton())
+    @assert norm(res.minimum - prob.solutions) < 1e-10
+end


### PR DESCRIPTION
I have no idea where I pulled the other request from in #123 . Made a branch here instead.

```julia
julia> using Optim

julia> prob=Optim.UnconstrainedProblems.examples["Himmelblau"]
Optim.UnconstrainedProblems.OptimizationProblem("Himmelblau",Optim.UnconstrainedProblems.himmelblau,Optim.UnconstrainedProblems.himmelblau_gradient!,Optim.UnconstrainedProblems.himmelblau_hessian!,[2.0,2.0],[3.0,2.0],true,true)

julia> ddf = TwiceDifferentiableFunction(prob.f, prob.g!,prob.h!)
Optim.TwiceDifferentiableFunction(Optim.UnconstrainedProblems.himmelblau,Optim.UnconstrainedProblems.himmelblau_gradient!,fg!,Optim.UnconstrainedProblems.himmelblau_hessian!)

julia> res = optimize(ddf, [0., 0.], ModifiedNewton())
Results of Optimization Algorithm
 * Algorithm: Modified Newton's Method
 * Starting Point: [0.0,0.0]
 * Minimum: [2.9999999999873177,2.0000000000110285]
 * Value of Function at Minimum: 0.000000
 * Iterations: 7
 * Convergence: true
   * |x - x'| < 1.0e-32: false
   * |f(x) - f(x')| / |f(x)| < 1.0e-08: false
   * |g(x)| < 1.0e-08: true
   * Exceeded Maximum Number of Iterations: false
 * Objective Function Calls: 33
 * Gradient Call: 33

julia> optimize(ddf, [0., 0.], Newton())
ERROR: Search direction is not a direction of descent; this error may indicate that user-provided derivatives are inaccurate. (dphia = 23.282051; dphib = 0.103816)
 in error at ./error.jl:21
 [inlined code] from printf.jl:145
 in secant2! at /home/pkm/Optim.jl/src/linesearch/hz_linesearch.jl:402
 in hz_linesearch! at /home/pkm/Optim.jl/src/linesearch/hz_linesearch.jl:321
 in hz_linesearch! at /home/pkm/Optim.jl/src/linesearch/hz_linesearch.jl:176 (repeats 10 times)
 in optimize at /home/pkm/Optim.jl/src/newton.jl:108
 in optimize at /home/pkm/Optim.jl/src/optimize.jl:119

julia> @assert norm(res.minimum - prob.solutions) < 1e-10
```
Thanks for the wonderful tool @timholy !

I'm thinking we really just do this by default, but that's of course something we need to discuss.