### PR TITLE
Fix minimum value, max iteration break condition, fix the use of appe…

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,10 +278,20 @@ x0 = [2.0, 2.0]
 results = optimize(d4, x0, l, u, Fminbox())  # d4 from rosenbrock example
 ```
 
-This performs optimization with a barrier penalty, successively scaling down the barrier coefficient and using `cg` for convergence at each step.
+This performs optimization with a barrier penalty, successively scaling down the barrier coefficient and using `ConjugateGradient` for convergence at each step.
 
-This algorithm uses diagonal preconditioning to improve the accuracy, and hence is a good example of how to use `cg` with preconditioning. Only the box constraints are used. If you can analytically compute the diagonal of the Hessian of your objective function, you may want to consider writing your own preconditioner (see `nnls` for an example).
+This algorithm uses diagonal preconditioning to improve the accuracy, and hence is a good example of how to use `ConjugateGradient` with preconditioning. Only the box constraints are used. If you can analytically compute the diagonal of the Hessian of your objective function, you may want to consider writing your own preconditioner.
 
+There are two iterations parameters: an outer iterations parameter used to control `Fminbox` and an inner iterations parameter used to control `ConjugateGradient`. For this reason, the options syntax is a bit different from the rest of the package. All parameters regarding the outer iterations are passed as keyword arguments, and options for the interior optimizer is passed as an `OptimizationOptions` type using the keyword `optimizer_o`.
+
+For example, the following restricts the optimization to 2 major iterations
+```julia
+results = optimize(objective, x0, l, u, Fminbox(); iterations = 2)
+```
+In contrast, the following sets the maximum number of iterations for each `ConjugateGradient` optimization to 2
+```julia
+results = Optim.optimize(objective, x0, l, u, Fminbox(); optimizer_o = OptimizationOptions(iterations = 2))
+```
 ### Linear programming
 
 For linear programming and extensions, see the [JuMP](https://github.com/JuliaOpt/JuMP.jl) and [MathProgBase](https://github.com/JuliaOpt/MathProgBase.jl) packages.

--- a/src/deprecate.jl
+++ b/src/deprecate.jl
@@ -85,4 +85,3 @@ end
 @deprecate fminbox{T<:AbstractFloat}(df::DifferentiableFunction,
                     initial_x::Array{T}, l::Array{T}, u::Array{T};
                     optimizer = cg, nargs...) optimize(df, initial_x, l, u, Fminbox(); optimizer = get_optimizer(symbol(optimizer)), nargs...)
-

--- a/src/types.jl
+++ b/src/types.jl
@@ -190,7 +190,7 @@ function Base.append!(a::MultivariateOptimizationResults, b::MultivariateOptimiz
     a.x_converged = b.x_converged
     a.f_converged = b.f_converged
     a.gr_converged = b.gr_converged
-    append!(a.trace, b.trace)
+    append!(a.trace.states, b.trace.states)
     a.f_calls += b.f_calls
     a.g_calls += b.g_calls
 end

--- a/test/constrained.jl
+++ b/test/constrained.jl
@@ -49,3 +49,13 @@ objective.fg!(results.minimum, g)
 for i = 1:N
     @test abs(g[i]) < 3e-3 || (results.minimum[i] < -boxl+1e-3 && g[i] > 0) || (results.minimum[i] > boxl-1e-3 && g[i] < 0)
 end
+
+# tests for #180
+results = Optim.optimize(objective, x0, l, u, Fminbox(); iterations = 2)
+@test results.iterations == 2
+@test results.f_minimum == objective.f(results.minimum)
+
+# might fail if changes are made to Optim.jl
+# TODO: come up with a better test
+results = Optim.optimize(objective, x0, l, u, Fminbox(); optimizer_o = OptimizationOptions(iterations = 2))
+@test results.iterations == 470


### PR DESCRIPTION
…nd, and remove export.

Fixes #167 

I don't think it's unreasonable for `f_minimum` to return the objective function value at the minimizer, even if a barrier function was added during optimization.

<s>I also added `results.iterations >= iterations`. Before, the algorithm could run beyond the stated maximum number of iterations.</s>
I've also added separate outer and inner options.

Added `first = false` if in the `first == true` branch of the `append!` part of the code, this fixes the returned `MultivariateOptimizationResults` such that it actually adds all calls and iterations together.