### PR TITLE
Modifications and Extension of Preconditioning

### DIFF
--- a/src/Optim.jl
+++ b/src/Optim.jl
@@ -59,6 +59,9 @@ module Optim
     include(joinpath("linesearch", "mt_linesearch.jl"))
     include(joinpath("linesearch", "hz_linesearch.jl"))
 
+    # preconditioning functionality
+    include("precon.jl")
+
     # Gradient Descent
     include("gradient_descent.jl")
     include("accelerated_gradient_descent.jl")

--- a/src/cg.jl
+++ b/src/cg.jl
@@ -1,30 +1,3 @@
-# Preconditioners
-#  * Empty preconditioner
-cg_precondfwd(out::Array, P::Void, A::Array) = copy!(out, A)
-cg_precondfwddot(A::Array, P::Void, B::Array) = vecdot(A, B)
-cg_precondinvdot(A::Array, P::Void, B::Array) = vecdot(A, B)
-
-# Diagonal preconditioner
-function cg_precondfwd(out::Array, p::Vector, A::Array)
-    @simd for i in 1:length(A)
-        @inbounds out[i] = p[i] * A[i]
-    end
-    return out
-end
-function cg_precondfwddot{T}(A::Array{T}, p::Vector, B::Array)
-    s = zero(T)
-    @simd for i in 1:length(A)
-        @inbounds s += A[i] * p[i] * B[i]
-    end
-    return s
-end
-function cg_precondinvdot{T}(A::Array{T}, p::Vector, B::Array)
-    s = zero(T)
-    @simd for i in 1:length(A)
-        @inbounds s += A[i] * B[i] / p[i]
-    end
-    return s
-end
 
 #
 # Conjugate gradient
@@ -106,16 +79,14 @@ end
 immutable ConjugateGradient{T} <: Optimizer
     eta::Float64
     P::T
-    precondprep::Function
     linesearch!::Function
 end
 
 function ConjugateGradient(;
                            linesearch!::Function = hz_linesearch!,
                            eta::Real = 0.4,
-                           P::Any = nothing,
-                           precondprep::Function = (P, x) -> nothing)
-    ConjugateGradient{typeof(P)}(Float64(eta), P, precondprep, linesearch!)
+                           P::Any = nothing)
+    ConjugateGradient{typeof(P)}(Float64(eta), P, linesearch!)
 end
 
 function optimize{T}(df::DifferentiableFunction,
@@ -184,8 +155,8 @@ function optimize{T}(df::DifferentiableFunction,
     end
 
     # Determine the intial search direction
-    cg.precondprep(cg.P, x)
-    cg_precondfwd(s, cg.P, gr)
+    precondprep!(cg.P, x)
+    precondfwd(s, cg.P, gr)
     scale!(s, -1)
 
     # Assess multiple types of convergence
@@ -257,15 +228,15 @@ function optimize{T}(df::DifferentiableFunction,
 
         # Determine the next search direction using HZ's CG rule
         #  Calculate the beta factor (HZ2012)
-        cg.precondprep(cg.P, x)
-        dPd = cg_precondinvdot(s, cg.P, s)
+        precondprep!(cg.P, x)
+        dPd = precondinvdot(s, cg.P, s)
         etak::T = cg.eta * vecdot(s, gr_previous) / dPd
         @simd for i in 1:n
             @inbounds y[i] = gr[i] - gr_previous[i]
         end
         ydots = vecdot(y, s)
-        cg_precondfwd(pgr, cg.P, gr)
-        betak = (vecdot(y, pgr) - cg_precondfwddot(y, cg.P, y) *
+        precondfwd(pgr, cg.P, gr)
+        betak = (vecdot(y, pgr) - precondfwddot(y, cg.P, y) *
                  vecdot(gr, s) / ydots) / ydots
         beta = max(betak, etak)
         @simd for i in 1:n

--- a/src/deprecate.jl
+++ b/src/deprecate.jl
@@ -35,8 +35,7 @@ end
                 linesearch!::Function = hz_linesearch!,
                 eta::Real = convert(T,0.4),
                 P::Any = nothing,
-                precondprep::Function = (P, x) -> nothing,
-                nargs...) optimize(df, initial_x, ConjugateGradient(eta = eta, precondprep = precondprep, P = P, linesearch! = linesearch!), OptimizationOptions(;nargs...))
+                nargs...) optimize(df, initial_x, ConjugateGradient(eta = eta, P = P, linesearch! = linesearch!), OptimizationOptions(;nargs...))
 
 @deprecate gradient_descent{T}(df::Union{DifferentiableFunction, TwiceDifferentiableFunction},
                 initial_x::Array{T};

--- a/src/fminbox.jl
+++ b/src/fminbox.jl
@@ -93,7 +93,7 @@ end
 
 # Default preconditioner for box-constrained optimization
 # This creates the inverse Hessian of the barrier penalty
-function precondprepbox(P, x, l, u, mu)
+function precondprepbox!(P, x, l, u, mu)
     @inbounds @simd for i = 1:length(x)
         xi = x[i]
         li = l[i]
@@ -126,7 +126,7 @@ function optimize{T<:AbstractFloat}(
         eta::Real = convert(T,0.4),
         mu0::T = convert(T, NaN),
         mufactor::T = convert(T, 0.001),
-        precondprep = (P, x, l, u, mu) -> precondprepbox(P, x, l, u, mu),
+        precondprep! = (P, x, l, u, mu) -> precondprepbox!(P, x, l, u, mu),
         optimizer = ConjugateGradient,
         optimizer_o = OptimizationOptions(store_trace = store_trace,
                                           show_trace = show_trace,
@@ -184,8 +184,8 @@ function optimize{T<:AbstractFloat}(
         if show_trace > 0
             println("#### Calling optimizer with mu = ", mu, " ####")
         end
-        pcp = (P, x) -> precondprep(P, x, l, u, mu)
-        resultsnew = optimize(dfbox, x, optimizer(eta = eta, linesearch! = linesearch!, P = P, precondprep = pcp),
+        pcp = (P, x) -> precondprep!(P, x, l, u, mu)
+        resultsnew = optimize(dfbox, x, optimizer(eta = eta, linesearch! = linesearch!, P = P, precondprep! = pcp),
                               optimizer_o)
         if first
             results = resultsnew

--- a/src/l_bfgs.jl
+++ b/src/l_bfgs.jl
@@ -13,7 +13,8 @@ function twoloop!(s::Vector,
                   m::Integer,
                   pseudo_iteration::Integer,
                   alpha::Vector,
-                  q::Vector)
+                  q::Vector,
+                  precon)
     # Count number of parameters
     n = length(s)
 
@@ -37,7 +38,9 @@ function twoloop!(s::Vector,
     end
 
     # Copy q into s for forward pass
-    copy!(s, q)
+    # apply preconditioner if precon != nothing
+    # (Note: preconditioner update was done outside of this function)
+    precondfwd!(s, precon, q)
 
     # Forward pass
     for index in lower:1:upper
@@ -80,13 +83,16 @@ macro lbfgstrace()
     end
 end
 
-immutable LBFGS <: Optimizer
+immutable LBFGS{T} <: Optimizer
     m::Int
     linesearch!::Function
+    P::T
+    precondprep!::Function
 end
 
-LBFGS(; m::Integer = 10, linesearch!::Function = hz_linesearch!) =
-  LBFGS(Int(m), linesearch!)
+LBFGS(; m::Integer = 10, linesearch!::Function = hz_linesearch!,
+      P=nothing, precondprep! = (P, x) -> nothing) =
+    LBFGS(Int(m), linesearch!, P, precondprep!)
 
 function optimize{T}(d::DifferentiableFunction,
                      initial_x::Vector{T},
@@ -156,9 +162,12 @@ function optimize{T}(d::DifferentiableFunction,
         iteration += 1
         pseudo_iteration += 1
 
+        # update the preconditioner
+        mo.precondprep!(mo.P, x)
+        
         # Determine the L-BFGS search direction
         twoloop!(s, gr, rho, dx_history, dgr_history, mo.m, pseudo_iteration,
-                 twoloop_alpha, twoloop_q)
+                 twoloop_alpha, twoloop_q, mo.P)
 
         # Refresh the line search cache
         dphi0 = vecdot(gr, s)

--- a/src/precon.jl
+++ b/src/precon.jl
@@ -1,0 +1,63 @@
+
+
+# Standard Preconditioners
+#
+# Meaning of P:
+#    P^{-1} ≈ ∇²E, so the preconditioned gradient is P ∇E
+#    this means all functionality can be implemented by
+#       P * x        >>> precondfwd
+#       <x|P|y>      >>> precondfwddot
+#      <x|P^{-1}|y>  >>> precondinvdot
+# and finally an update function >>>>> precondprep!
+
+#####################################################
+#  [1] Empty preconditioner
+
+# out =  P * A
+precondfwd(out::Array, P::Void, A::Array) = copy!(out, A)
+# A' * P * B
+precondfwddot(A::Array, P::Void, B::Array) = vecdot(A, B)
+# A' * P^{-1} B
+precondinvdot(A::Array, P::Void, B::Array) = vecdot(A, B)
+# ????? update the preconditioner ?????
+precondprep!(P::Void, x) = nothing
+
+
+#####################################################
+#  [2] Diagonal preconditioner
+
+function precondfwd{T}(out::Array, p::Vector, A::Array{T})
+    @simd for i in 1:length(A)
+        @inbounds out[i] = p[i] * A[i]
+    end
+    return out
+end
+function precondfwddot{T}(A::Array{T}, p::Vector, B::Array)
+    s = zero(T)
+    @simd for i in 1:length(A)
+        @inbounds s += A[i] * p[i] * B[i]
+    end
+    return s
+end
+function precondinvdot{T}(A::Array{T}, p::Vector, B::Array)
+    s = zero(T)
+    @simd for i in 1:length(A)
+        @inbounds s += A[i] * B[i] / p[i]
+    end
+    return s
+end
+
+precondprep!(P::Vector, x) = nothing
+
+
+#####################################################
+#  [3] Constant Matrix Preconditioner
+#  this assumption here is that P is given by its inverse, which
+#  is more typical
+
+PMAT = Union{Matrix,SparseMatrixCSC}
+precondfwd(out::Vector, P::PMAT, A::Vector) = copy!(out, P \ A)
+precondfwddot(A::Vector, P::PMAT, B::Vector) = dot(A, P \ B)
+precondinvdot(A::Vector, P::PMAT, B::Vector) = dot(A, P * B)
+precondprep!(P::PMAT, x) = nothing
+

--- a/test/precon.jl
+++ b/test/precon.jl
@@ -1,0 +1,55 @@
+
+using Optim
+
+
+# this implements the 1D p-laplacian (p = 4)
+#   F(u) = ∑_{i=1}^{N} h (W(u_i') - ∑_{i=1}^{N-1} h u_i
+#  where u_i' = (u_i - u_{i-1})/h
+#  plap: implements the functional without boundary condition
+#  objective : applies Dirichlet boundary conditions u_0 = u_N = 0
+W(r) = (1+r.^2).^2
+W1(r) = 4 * (1+r.^2) .* r
+h(U) = length(U)-1
+plap(U) = h(U) * sum( W(diff(U)) ) - sum(U) / h(U)
+plap1(U) = h(U) * ([0.0; W1(diff(U))] - [W1(diff(U)); 0.0]) - ones(U) / h(U)
+plap_objective(X::Vector) = plap([0;X;0])
+plap_objective_gradient!(X::Vector, G) = copy!(G, plap1([0;X;0])[2:end-1])
+
+# discrete laplacian as a preconditioner
+# note for this example we could just use the hessian itself, but
+#  this is not the point here, we just want to check that preconditioning
+#  works fine.
+lap_precond(X::Vector) =
+    spdiagm( ( (-1) * ones(length(X)-1),
+                 2  * ones(length(X)),
+               (-1) * ones(length(X)-1) ),
+             (-1,0,1), length(X), length(X) ) * (length(X)+1)
+
+
+df = DifferentiableFunction(plap_objective, plap_objective_gradient!)
+GRTOL = 1e-8
+
+println("Test a basic preconditioning example")
+for N in (10, 100, 1000)
+    println("N = ", N)
+    x0 = zeros(N)
+    Plap = lap_precond(x0)
+    ID = nothing
+    for Optimiser in (GradientDescent, ConjugateGradient, LBFGS)
+        for (P, wwo) in zip((ID, Plap), (" WITHOUT", " WITH"))
+            results = Optim.optimize(df, copy(x0),
+                                     method=Optimiser(P = P),
+                                     ftol = 1e-32, grtol = GRTOL )
+            println(Optimiser, wwo, 
+                    " preconditioning : g_calls = ", results.g_calls,
+                    ", f_calls = ", results.f_calls)
+            if (Optimiser == GradientDescent) && (N > 15) && (P == ID)
+                println("    (gradient descent is not expected to converge)")
+            else
+                @assert Optim.converged(results)
+            end
+        end
+    end
+end
+
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,7 +24,7 @@ my_tests = [
     "brent.jl",
     "type_stability.jl",
     "array.jl",
-    "constrained.jl",
+    # "constrained.jl",
     "callbacks.jl",
     "deprecate.jl"
 ]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,9 +24,10 @@ my_tests = [
     "brent.jl",
     "type_stability.jl",
     "array.jl",
-    # "constrained.jl",
+    "constrained.jl",
     "callbacks.jl",
-    "deprecate.jl"
+    "deprecate.jl",
+    "precon.jl"
 ]
 
 println("Running tests:")


### PR DESCRIPTION
This was discussed in [Issue 188](https://github.com/JuliaOpt/Optim.jl/issues/188).

* created `precon.jl`
* added preconditioning to `GradientDescent` and to `LBFGS`
* added `test/precon.jl` to test preconditioning capabilities
* added a matrix preconditioner

Documentation has been added in a separate [pull request #190 ](https://github.com/JuliaOpt/Optim.jl/pull/190).

I think this is just a quick and dirty implementation. I suggest more 
substantial changes in this direction in [Issue 188](https://github.com/JuliaOpt/Optim.jl/issues/188).