### PR TITLE
Control flow check values of f_ instead of x_

### DIFF
--- a/src/brent.jl
+++ b/src/brent.jl
@@ -140,12 +140,12 @@ function optimize{T <: AbstractFloat}(
             else
                 x_upper = x_new
             end
-            if x_new <= x_minimum_old || x_minimum_old == x_minimum
+            if f_new <= f_minimum_old || x_minimum_old == x_minimum
                 x_minimum_old_old = x_minimum_old
                 f_minimum_old_old = f_minimum_old
                 x_minimum_old = x_new
                 f_minimum_old = f_new
-            elseif x_new <= x_minimum_old_old || x_minimum_old_old == x_minimum || x_minimum_old_old == x_minimum_old
+            elseif f_new <= f_minimum_old_old || x_minimum_old_old == x_minimum || x_minimum_old_old == x_minimum_old
                 x_minimum_old_old = x_new
                 f_minimum_old_old = f_new
             end


### PR DESCRIPTION
It seems like a mistake to compare `x_new` with `x_minimum_old` etc. in order to decide whether it is a better minimiser. I assume it was meant to be a comparison between `f_new` and `f_minimum_old` etc.