### PR TITLE
added bounds argument to levenberg_marquardt

### DIFF
--- a/test/levenberg_marquardt.jl
+++ b/test/levenberg_marquardt.jl
@@ -52,3 +52,33 @@ let
 
     @assert norm(Optim.minimizer(results) - [1.0, 2.0]) < 0.05
 end
+
+# tests for box constraints, PR #196
+let
+    srand(12345)
+
+    model(x, p) = p[1]*exp(-x./p[2])+p[3]
+
+    xdata = 1:100
+    ydata = model(xdata, [10.0, 10.0, 10.0]) + 0.1*randn(length(xdata))
+
+    f_lsq = p -> model(xdata,p)-ydata
+    g_lsq = Calculus.jacobian(f_lsq)
+
+    @test_throws ArgumentError Optim.levenberg_marquardt(f_lsq, g_lsq, [15.0, 15.0, 15.0], lower=[5.0, 11.0])
+    @test_throws ArgumentError Optim.levenberg_marquardt(f_lsq, g_lsq, [5.0, 5.0, 5.0], upper=[15.0, 9.0])
+    @test_throws ArgumentError Optim.levenberg_marquardt(f_lsq, g_lsq, [15.0, 10.0, 15.0], lower=[5.0, 11.0, 5.0])
+    @test_throws ArgumentError Optim.levenberg_marquardt(f_lsq, g_lsq, [5.0, 10.0, 5.0], upper=[15.0, 9.0, 15.0])
+
+    lower=[5.0, 11.0, 5.0]
+    results = Optim.levenberg_marquardt(f_lsq, g_lsq, [15.0, 15.0, 15.0], lower=lower)
+    Optim.minimizer(results)
+    @test Optim.converged(results)
+    @test all(Optim.minimizer(results) .>= lower)
+
+    upper=[15.0, 9.0, 15.0]
+    results = Optim.levenberg_marquardt(f_lsq, g_lsq, [5.0, 5.0, 5.0], upper=upper)
+    Optim.minimizer(results)
+    @test Optim.converged(results)
+    @test all(Optim.minimizer(results) .<= upper)
+end


### PR DESCRIPTION
clamping the search space drastically improves the fit in my use case, and prevents `SingularException`s being thrown.

while at it i also reformatted the docs to conform to current guidelines.