### PR TITLE
Re-implemented Preconditioning

### DIFF
--- a/src/cg.jl
+++ b/src/cg.jl
@@ -126,6 +126,7 @@ function optimize{T}(df::DifferentiableFunction,
 
     # Intermediate value in CG calculation
     y = similar(x)
+    py = similar(x)
 
     # Store f(x) in f_x
     f_x = df.fg!(x, gr)
@@ -159,9 +160,11 @@ function optimize{T}(df::DifferentiableFunction,
     end
 
     # Determine the intial search direction
+    #    if we don't precondition, then this is an extra superfluous copy
+    #    TODO: consider allowing a reference for pgr instead of a copy
     mo.precondprep!(mo.P, x)
-    precondfwd!(s, mo.P, gr)
-    scale!(s, -1)
+    A_ldiv_B!(pgr, mo.P, gr)
+    scale!(copy!(s, pgr), -1)
 
     # Assess multiple types of convergence
     x_converged, f_converged, gr_converged = false, false, false
@@ -176,7 +179,7 @@ function optimize{T}(df::DifferentiableFunction,
         dphi0 = vecdot(gr, s)
         if dphi0 >= 0
             @simd for i in 1:n
-                @inbounds s[i] = -gr[i]
+                @inbounds s[i] = -pgr[i]
             end
             dphi0 = vecdot(gr, s)
             if dphi0 < 0
@@ -232,16 +235,26 @@ function optimize{T}(df::DifferentiableFunction,
 
         # Determine the next search direction using HZ's CG rule
         #  Calculate the beta factor (HZ2012)
+        # -----------------
+        # Comment on py: one could replace the computation of py with
+        #    ydotpgrprev = vecdot(y, pgr)
+        #    vecdot(y, py)  >>>  vecdot(y, pgr) - ydotpgrprev
+        # but I am worried about round-off here, so instead we make an
+        # extra copy, which is probably minimal overhead.
+        # -----------------
         mo.precondprep!(mo.P, x)
-        dPd = precondinvdot(s, mo.P, s)
+        dPd = dot(s, mo.P, s)
         etak::T = mo.eta * vecdot(s, gr_previous) / dPd
         @simd for i in 1:n
             @inbounds y[i] = gr[i] - gr_previous[i]
         end
         ydots = vecdot(y, s)
-        precondfwd!(pgr, mo.P, gr)
-        betak = (vecdot(y, pgr) - precondfwddot(y, mo.P, y) *
-                 vecdot(gr, s) / ydots) / ydots
+        copy!(py, pgr)        # below, store pgr - pgr_previous in py
+        A_ldiv_B!(pgr, mo.P, gr)
+        @simd for i in 1:n     # py = pgr - py
+           @inbounds py[i] = pgr[i] - py[i]
+        end
+        betak = (vecdot(y, pgr) - vecdot(y, py) * vecdot(gr, s) / ydots) / ydots
         beta = max(betak, etak)
         @simd for i in 1:n
             @inbounds s[i] = beta * s[i] - pgr[i]

--- a/src/fminbox.jl
+++ b/src/fminbox.jl
@@ -98,7 +98,7 @@ function precondprepbox!(P, x, l, u, mu)
         xi = x[i]
         li = l[i]
         ui = u[i]
-        P[i] = 1/(mu*(1/(xi-li)^2 + 1/(ui-xi)^2) + 1) # +1 like identity far from edges
+        P.diag[i] = 1/(mu*(1/(xi-li)^2 + 1/(ui-xi)^2) + 1) # +1 like identity far from edges
     end
 end
 
@@ -138,7 +138,7 @@ function optimize{T<:AbstractFloat}(
     fb = (x, gfunc, gbarrier) -> function_barrier(x, gfunc, gbarrier, df.fg!, fbarrier)
     gfunc = similar(x)
     gbarrier = similar(x)
-    P = Array(T, length(initial_x))
+    P = InverseDiagonal(Array(T, length(initial_x)))
     # to be careful about one special case that might occur commonly
     # in practice: the initial guess x is exactly in the center of the
     # box. In that case, gbarrier is zero. But since the

--- a/src/gradient_descent.jl
+++ b/src/gradient_descent.jl
@@ -90,7 +90,7 @@ function optimize{T}(d::DifferentiableFunction,
 
         # Search direction is always the negative preconditioned gradient
         mo.precondprep!(mo.P, x)
-        precondfwd!(s, mo.P, gr)
+        A_ldiv_B!(s, mo.P, gr)
         @simd for i in 1:n
             @inbounds s[i] = -s[i]
         end

--- a/src/l_bfgs.jl
+++ b/src/l_bfgs.jl
@@ -40,7 +40,7 @@ function twoloop!(s::Vector,
     # Copy q into s for forward pass
     # apply preconditioner if precon != nothing
     # (Note: preconditioner update was done outside of this function)
-    precondfwd!(s, precon, q)
+    A_ldiv_B!(s, precon, q)
 
     # Forward pass
     for index in lower:1:upper

--- a/test/precon.jl
+++ b/test/precon.jl
@@ -7,9 +7,10 @@
 #     equivalent (in the limit h → 0) to that induced by the hessian, but
 #     does not approximate the hessian explicitly.
 
-using Optim, ForwardDiff
+using Optim
 plap(U; n=length(U)) = (n-1) * sum( (0.1 + diff(U).^2).^2 ) - sum(U) / (n-1)
-plap1 = ForwardDiff.gradient(plap)
+plap1(U; n=length(U), dU = diff(U), dW = 4 * (0.1 + dU.^2) .* dU) =
+                                 n * ([0.0; dW] - [dW; 0.0]) - ones(U) / n
 precond(x::Vector) = precond(length(x))
 precond(n::Number) = spdiagm( ( -ones(n-1), 2*ones(n), -ones(n-1) ),
                               (-1,0,1), n, n) * (n+1)

--- a/test/precon.jl
+++ b/test/precon.jl
@@ -10,7 +10,7 @@
 using Optim
 plap(U; n=length(U)) = (n-1) * sum( (0.1 + diff(U).^2).^2 ) - sum(U) / (n-1)
 plap1(U; n=length(U), dU = diff(U), dW = 4 * (0.1 + dU.^2) .* dU) =
-                                 n * ([0.0; dW] - [dW; 0.0]) - ones(U) / n
+                        (n-1) * ([0.0; dW] - [dW; 0.0]) - ones(U) / (n-1)
 precond(x::Vector) = precond(length(x))
 precond(n::Number) = spdiagm( ( -ones(n-1), 2*ones(n), -ones(n-1) ),
                               (-1,0,1), n, n) * (n+1)

--- a/test/precon.jl
+++ b/test/precon.jl
@@ -1,46 +1,35 @@
 
-using Optim
-
-
 # this implements the 1D p-laplacian (p = 4)
-#   F(u) = ∑_{i=1}^{N} h (W(u_i') - ∑_{i=1}^{N-1} h u_i
+#      F(u) = ∑_{i=1}^{N} h (W(u_i') - ∑_{i=1}^{N-1} h u_i
 #  where u_i' = (u_i - u_{i-1})/h
 #  plap: implements the functional without boundary condition
-#  objective : applies Dirichlet boundary conditions u_0 = u_N = 0
-W(r) = (1+r.^2).^2
-W1(r) = 4 * (1+r.^2) .* r
-h(U) = length(U)-1
-plap(U) = h(U) * sum( W(diff(U)) ) - sum(U) / h(U)
-plap1(U) = h(U) * ([0.0; W1(diff(U))] - [W1(diff(U)); 0.0]) - ones(U) / h(U)
-plap_objective(X::Vector) = plap([0;X;0])
-plap_objective_gradient!(X::Vector, G) = copy!(G, plap1([0;X;0])[2:end-1])
+#  preconditioner is a discrete laplacian, which defines a metric
+#     equivalent (in the limit h → 0) to that induced by the hessian, but
+#     does not approximate the hessian explicitly.
 
-# discrete laplacian as a preconditioner
-# note for this example we could just use the hessian itself, but
-#  this is not the point here, we just want to check that preconditioning
-#  works fine.
-lap_precond(X::Vector) =
-    spdiagm( ( (-1) * ones(length(X)-1),
-                 2  * ones(length(X)),
-               (-1) * ones(length(X)-1) ),
-             (-1,0,1), length(X), length(X) ) * (length(X)+1)
+using Optim, ForwardDiff
+plap(U; n=length(U)) = (n-1) * sum( (0.1 + diff(U).^2).^2 ) - sum(U) / (n-1)
+plap1 = ForwardDiff.gradient(plap)
+precond(x::Vector) = precond(length(x))
+precond(n::Number) = spdiagm( ( -ones(n-1), 2*ones(n), -ones(n-1) ),
+                              (-1,0,1), n, n) * (n+1)
+df = DifferentiableFunction( X->plap([0;X;0]),
+                             (X, G)->copy!(G, (plap1([0;X;0]))[2:end-1]) )
 
-
-df = DifferentiableFunction(plap_objective, plap_objective_gradient!)
-GRTOL = 1e-8
+GRTOL = 1e-6
 
 println("Test a basic preconditioning example")
-for N in (10, 100, 1000)
+for N in (10, 50, 250)
     println("N = ", N)
     x0 = zeros(N)
-    Plap = lap_precond(x0)
+    Plap = precond(x0)
     ID = nothing
     for Optimiser in (GradientDescent, ConjugateGradient, LBFGS)
         for (P, wwo) in zip((ID, Plap), (" WITHOUT", " WITH"))
             results = Optim.optimize(df, copy(x0),
                                      method=Optimiser(P = P),
                                      ftol = 1e-32, grtol = GRTOL )
-            println(Optimiser, wwo, 
+            println(Optimiser, wwo,
                     " preconditioning : g_calls = ", results.g_calls,
                     ", f_calls = ", results.f_calls)
             if (Optimiser == GradientDescent) && (N > 15) && (P == ID)
@@ -51,5 +40,3 @@ for N in (10, 100, 1000)
         end
     end
 end
-
-


### PR DESCRIPTION
This uses only method that are available in base and hence can be easily overloaded without needing to import anything from `Optim.jl`.  The main "conceptual change" is that `P` now described the matrix and not its inverse. This is good for consistency with the iterative linear algebra packages.

A few specific items to consider when reviewing:
* `Base.A_ldiv_B!(x, P::AbstractMatrix, b)` is not implemented in Base, though there is a pull request for it. I now added it to precon.jl, but will remove it once it is no longer necessary.
* I kept the name `precondprep!` for the sake of history, though was tempted to replace it with `updateP!`, which I think is more descriptive. (but no big deal)\
* for the diagonal preconditions I replaced SIMD loops with standard vectorised instructions. I just thought this was overkill, but I am happy to reverse this if so desired.

**EDIT:** I am no convinced that `precondprep!` needs to remain an argument.

* `precondprep!`: ~~My original intent was to replace it with a dispatch mechanism, but then this creates the problem that it has to imported as there is no general abstract interface that one could import instead. passing it as an argument remains more flexible. However, I would be happy to discuss this point.~~
