### PR TITLE
Fix norm -> vecnorm.

### DIFF
--- a/src/accelerated_gradient_descent.jl
+++ b/src/accelerated_gradient_descent.jl
@@ -14,7 +14,7 @@ macro agdtrace()
                 dt["x"] = copy(x)
                 dt["g(x)"] = copy(gr)
             end
-            grnorm = norm(gr, Inf)
+            grnorm = vecnorm(gr, Inf)
             update!(tr,
                     iteration,
                     f_x,

--- a/src/bfgs.jl
+++ b/src/bfgs.jl
@@ -11,7 +11,7 @@ macro bfgstrace()
                 dt["g(x)"] = copy(gr)
                 dt["~inv(H)"] = copy(invH)
             end
-            grnorm = norm(gr, Inf)
+            grnorm = vecnorm(gr, Inf)
             update!(tr,
                     iteration,
                     f_x,

--- a/src/cg.jl
+++ b/src/cg.jl
@@ -62,7 +62,7 @@ macro cgtrace()
                 dt["g(x)"] = copy(gr)
                 dt["Current step size"] = alpha
             end
-            grnorm = norm(gr[:], Inf)
+            grnorm = vecnorm(gr, Inf)
             update!(tr,
                     iteration,
                     f_x,

--- a/src/gradient_descent.jl
+++ b/src/gradient_descent.jl
@@ -8,7 +8,7 @@ macro gdtrace()
                 dt["x"] = copy(x)
                 dt["g(x)"] = copy(gr)
             end
-            grnorm = norm(gr, Inf)
+            grnorm = vecnorm(gr, Inf)
             update!(tr,
                     iteration,
                     f_x,

--- a/src/l_bfgs.jl
+++ b/src/l_bfgs.jl
@@ -69,7 +69,7 @@ macro lbfgstrace()
                 dt["g(x)"] = copy(gr)
                 dt["Current step size"] = alpha
             end
-            grnorm = norm(gr, Inf)
+            grnorm = vecnorm(gr, Inf)
             update!(tr,
                     iteration,
                     f_x,

--- a/src/linesearch/hz_linesearch.jl
+++ b/src/linesearch/hz_linesearch.jl
@@ -68,7 +68,7 @@ function alphainit{T}(alpha::Real,
             if x_max != 0.0
                 alpha = psi0 * x_max / gr_max
             elseif f_x != 0.0
-                alpha = psi0 * abs(f_x) / norm(gr)
+                alpha = psi0 * abs(f_x) / vecnorm(gr)
             end
         end
     end

--- a/src/momentum_gradient_descent.jl
+++ b/src/momentum_gradient_descent.jl
@@ -9,7 +9,7 @@ macro mgdtrace()
                 dt["x"] = copy(x)
                 dt["g(x)"] = copy(gr)
             end
-            grnorm = norm(gr, Inf)
+            grnorm = vecnorm(gr, Inf)
             update!(tr,
                     iteration,
                     f_x,

--- a/src/newton.jl
+++ b/src/newton.jl
@@ -7,7 +7,7 @@ macro newtontrace()
                 dt["g(x)"] = copy(gr)
                 dt["h(x)"] = copy(H)
             end
-            grnorm = norm(gr, Inf)
+            grnorm = vecnorm(gr, Inf)
             update!(tr,
                     iteration,
                     f_x,

--- a/src/utilities/assess_convergence.jl
+++ b/src/utilities/assess_convergence.jl
@@ -19,7 +19,7 @@ function assess_convergence(x::Array,
         f_converged = true
     end
 
-    if norm(vec(gr), Inf) < grtol
+    if vecnorm(gr, Inf) < grtol
         gr_converged = true
     end
 

--- a/src/utilities/history.jl
+++ b/src/utilities/history.jl
@@ -7,7 +7,7 @@ function history()
                 dt["x"] = copy(x)
                 dt["g(x)"] = copy(gr)
             end
-            grnorm = norm(gr, Inf)
+            grnorm = vecnorm(gr, Inf)
             update!(tr,
                     iteration,
                     f_x,


### PR DESCRIPTION
A step towards restoring matrix input. I'm not sure if these were always formulated like this, but then the traced gradient has been the matrix norm, not the largest absolute value .

```jlcon

julia> A=rand(3,3)
3x3 Array{Float64,2}:
 0.336186  0.542031  0.82909 
 0.514256  0.872448  0.731126
 0.548907  0.672507  0.774536

julia> norm(A,Inf)
2.1178290608602834

julia> vecnorm(A, Inf)
0.8724475596453296

julia> a = rand(3,1)
3x1 Array{Float64,2}:
 0.0691116
 0.730404 
 0.3318   

julia> norm(a, Inf)
0.7304037281211753
```