### PR TITLE
Define endof for OptimizationTrace

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -111,8 +111,9 @@ function Base.show(io::IO, t::OptimizationState)
 end
 
 Base.push!(t::OptimizationTrace, s::OptimizationState) = push!(t.states, s)
-
 Base.getindex(t::OptimizationTrace, i::Integer) = getindex(t.states, i)
+Base.endof(t::OptimizationTrace) = endof(t.states)
+Base.length(t::OptimizationTrace) = length(t.states)
 
 function Base.setindex!(t::OptimizationTrace,
                         s::OptimizationState,

--- a/test/types.jl
+++ b/test/types.jl
@@ -3,6 +3,12 @@ module TestTypes
     using Compat
     using Optim
 
+    trace = OptimizationTrace(NelderMead())
+    push!(trace,OptimizationState{NelderMead}(1,1.0,1.0,Dict()))
+    push!(trace,OptimizationState{NelderMead}(2,1.0,1.0,Dict()))
+    @test length(trace) == 2
+    @test trace[end].iteration == 2
+
     prob = Optim.UnconstrainedProblems.examples["Rosenbrock"]
     f_prob = prob.f
     for g_free in (NelderMead(), SimulatedAnnealing())


### PR DESCRIPTION
I tried to access `trace[end]` in some code and ran into this error. I opened a PR since I don't see any reason to not add this.