### PR TITLE
Isolating tests, added univariate test problems, and better testing f…

### DIFF
--- a/src/Optim.jl
+++ b/src/Optim.jl
@@ -93,22 +93,6 @@ module Optim
     include("golden_section.jl")
     include("brent.jl")
 
-    const methods = Dict{Symbol, Type}(
-        :gradient_descent => GradientDescent,
-        :momentum_gradient_descent => MomentumGradientDescent,
-        :cg => ConjugateGradient,
-        :bfgs => BFGS,
-        :l_bfgs => LBFGS,
-        :newton => Newton,
-        :newton_tr => NewtonTrustRegion,
-        :nelder_mead => NelderMead,
-        :simulated_annealing => SimulatedAnnealing,
-        :particle_swarm => ParticleSwarm,
-        :brent => Brent,
-        :golden_section => GoldenSection,
-        :accelerated_gradient_descent => AcceleratedGradientDescent,
-        :fminbox => Fminbox)
-
     # Backward compatibility
     include("deprecate.jl")
 
@@ -117,6 +101,7 @@ module Optim
 
     # Examples for testing
     include(joinpath("problems", "unconstrained.jl"))
+    include(joinpath("problems", "univariate.jl"))
 
     cgdescent(args...) = error("API has changed. Please use cg.")
 end

--- a/src/problems/univariate.jl
+++ b/src/problems/univariate.jl
@@ -1,0 +1,51 @@
+module UnivariateProblems
+
+    ### Sources
+    ###
+    ### [1]  http://infinity77.net/global_optimization/test_functions_1d.html
+
+    immutable UnivariateProblem
+        name::AbstractString
+        f::Function
+        bounds::Vector{Float64}
+        minimizers::Vector{Float64}
+        minima::Vector{Float64}
+    end
+
+    examples = Dict{AbstractString, UnivariateProblem}()
+
+    f(x) = 2x^2+3x+1
+
+    examples["Polynomial"] = UnivariateProblem("Polynomial",
+                                                  f,
+                                                  [-2.0, 1.0],
+                                                  [-0.75,],
+                                                  [f(-0.75),])
+
+    # Problem 04 from [1]
+    p04(x) = -(16x^2-24x+5)exp(-x)
+
+    examples["Problem04"] = UnivariateProblem("Problem04",
+                                                p04,
+                                                [1.9, 3.9],
+                                                [2.868034,],
+                                                [p04(2.868034),])
+
+    # Problem 13 from [1]
+    p13(x) = -x^(2/3)-(1-x^2)^(1/3)
+
+    examples["Problem13"] = UnivariateProblem("Problem13",
+                                                p13,
+                                                [0.001, 0.99],
+                                                [1./sqrt(2.0),],
+                                                [p13(1./sqrt(2.0)),])
+
+    # Problem 18 from [1]
+    p18(x) = x <= 3.0 ? (x-2.0)^2 : 2.0*log(x-2.0)+1.0
+
+    examples["Problem18"] = UnivariateProblem("Problem18",
+                                                p18,
+                                                [0.0, 6.0],
+                                                [2.0,],
+                                                [p18(2.0),])
+end

--- a/test/accelerated_gradient_descent.jl
+++ b/test/accelerated_gradient_descent.jl
@@ -1,16 +1,17 @@
-using Optim
+# TODO expand tests here
+let
+    f(x) = x[1]^4
+    function g!(x, storage)
+        storage[1] = 4 * x[1]^3
+        return
+    end
 
-f(x) = x[1]^4
-function g!(x, storage)
-    storage[1] = 4 * x[1]^3
-    return
+    d = DifferentiableFunction(f, g!)
+
+    initial_x = [1.0]
+
+    Optim.optimize(d, initial_x,
+                   method = AcceleratedGradientDescent()
+                   show_trace = true,
+                   iterations = 10)
 end
-
-d = DifferentiableFunction(f, g!)
-
-initial_x = [1.0]
-
-Optim.optimize(d, initial_x,
-               method = AcceleratedGradientDescent()
-               show_trace = true,
-               iterations = 10)

--- a/test/api.jl
+++ b/test/api.jl
@@ -1,206 +1,132 @@
-function rosenbrock(x::Vector)
-    return (1.0 - x[1])^2 + 100.0 * (x[2] - x[1]^2)^2
-end
-
-function rosenbrock_gradient!(x::Vector, storage::Vector)
-    storage[1] = -2.0 * (1.0 - x[1]) - 400.0 * (x[2] - x[1]^2) * x[1]
-    storage[2] = 200.0 * (x[2] - x[1]^2)
-end
-
-function rosenbrock_hessian!(x::Vector, storage::Matrix)
-    storage[1, 1] = 2.0 - 400.0 * x[2] + 1200.0 * x[1]^2
-    storage[1, 2] = -400.0 * x[1]
-    storage[2, 1] = -400.0 * x[1]
-    storage[2, 2] = 200.0
-end
-
-f3 = rosenbrock
-g3! = rosenbrock_gradient!
-h3! = rosenbrock_hessian!
-
-d1 = DifferentiableFunction(rosenbrock)
-d2 = DifferentiableFunction(rosenbrock,
-	                        rosenbrock_gradient!)
-d3 = TwiceDifferentiableFunction(rosenbrock,
-	                             rosenbrock_gradient!,
-	                             rosenbrock_hessian!)
-
-Optim.optimize(f3, [0.0, 0.0], BFGS())
-Optim.optimize(f3, g3!, [0.0, 0.0], BFGS())
-Optim.optimize(f3, g3!, h3!, [0.0, 0.0], BFGS())
-Optim.optimize(d2, [0.0, 0.0], BFGS())
-Optim.optimize(d3, [0.0, 0.0], BFGS())
-
-Optim.optimize(f3, [0.0, 0.0], BFGS(), OptimizationOptions())
-Optim.optimize(f3, g3!, [0.0, 0.0], BFGS(), OptimizationOptions())
-Optim.optimize(f3, g3!, h3!, [0.0, 0.0], BFGS(), OptimizationOptions())
-Optim.optimize(d2, [0.0, 0.0], BFGS(), OptimizationOptions())
-Optim.optimize(d3, [0.0, 0.0], BFGS(), OptimizationOptions())
-
-Optim.optimize(d1, [0.0, 0.0], method = BFGS())
-Optim.optimize(d2, [0.0, 0.0], method = BFGS())
-
-Optim.optimize(d1, [0.0, 0.0], method = GradientDescent())
-Optim.optimize(d2, [0.0, 0.0], method = GradientDescent())
-
-Optim.optimize(d1, [0.0, 0.0], method = LBFGS())
-Optim.optimize(d2, [0.0, 0.0], method = LBFGS())
-
-Optim.optimize(rosenbrock, [0.0, 0.0], method = NelderMead())
-
-Optim.optimize(d3, [0.0, 0.0], method = Newton())
-
-Optim.optimize(rosenbrock, [0.0, 0.0], method = SimulatedAnnealing())
-
-optimize(rosenbrock,
-	     [0.0, 0.0],
-	     method = BFGS())
-optimize(rosenbrock,
-	     [0.0, 0.0],
-	     BFGS())
-optimize(rosenbrock,
-	     rosenbrock_gradient!,
-	     [0.0, 0.0],
-	     method = BFGS())
-optimize(rosenbrock,
-	     rosenbrock_gradient!,
-	     rosenbrock_hessian!,
-	     [0.0, 0.0],
-	     method = BFGS())
-
-optimize(rosenbrock,
-	     [0.0, 0.0],
-	     method = GradientDescent())
-optimize(rosenbrock,
-	     [0.0, 0.0],
-	     GradientDescent())
-optimize(rosenbrock,
-	     rosenbrock_gradient!,
-	     [0.0, 0.0],
-	     method = GradientDescent())
-optimize(rosenbrock,
-	     rosenbrock_gradient!,
-	     rosenbrock_hessian!,
-	     [0.0, 0.0],
-	     method = GradientDescent())
-
-optimize(rosenbrock,
-	     [0.0, 0.0],
-	     method = LBFGS())
-optimize(rosenbrock,
-	     [0.0, 0.0],
-	     LBFGS())
-optimize(rosenbrock,
-	     rosenbrock_gradient!,
-	     [0.0, 0.0],
-	     method = LBFGS())
-optimize(rosenbrock,
-	     rosenbrock_gradient!,
-	     rosenbrock_hessian!,
-	     [0.0, 0.0],
-	     method = LBFGS())
-
-optimize(rosenbrock,
-	     [0.0, 0.0],
-	     method = NelderMead())
-optimize(rosenbrock,
-	     [0.0, 0.0],
-	     NelderMead())
-optimize(rosenbrock,
-	     rosenbrock_gradient!,
-	     [0.0, 0.0],
-	     method = NelderMead())
-optimize(rosenbrock,
-	     rosenbrock_gradient!,
-	     rosenbrock_hessian!,
-	     [0.0, 0.0],
-	     method = NelderMead())
-
-optimize(rosenbrock,
-	     rosenbrock_gradient!,
-	     rosenbrock_hessian!,
-	     [0.0, 0.0],
-	     method = Newton())
-
-optimize(rosenbrock,
-	     [0.0, 0.0],
-	     method = SimulatedAnnealing())
-optimize(rosenbrock,
-	     [0.0, 0.0],
-	     SimulatedAnnealing())
-optimize(rosenbrock,
-	     rosenbrock_gradient!,
-	     [0.0, 0.0],
-	     method = SimulatedAnnealing())
-optimize(rosenbrock,
-	     rosenbrock_gradient!,
-	     rosenbrock_hessian!,
-	     [0.0, 0.0],
-	     method = SimulatedAnnealing())
-
-res = optimize(f3, g3!, h3!,
-	           [0.0, 0.0],
-	           method = BFGS(),
-	           g_tol = 1e-12,
-	           iterations = 10,
-	           store_trace = true,
-	           show_trace = false)
-
-res = optimize(f3, g3!, h3!,
-	           [0.0, 0.0],
-	           method = GradientDescent(),
-	           g_tol = 1e-12,
-	           iterations = 10,
-	           store_trace = true,
-	           show_trace = false)
-
-res = optimize(f3, g3!, h3!,
-	           [0.0, 0.0],
-	           method = LBFGS(),
-	           g_tol = 1e-12,
-	           iterations = 10,
-	           store_trace = true,
-	           show_trace = false)
-
-res = optimize(f3, g3!, h3!,
-	           [0.0, 0.0],
-	           method = NelderMead(),
-	           f_tol = 1e-12,
-	           iterations = 10,
-	           store_trace = true,
-	           show_trace = false)
-
-res = optimize(f3, g3!, h3!,
-	           [0.0, 0.0],
-	           method = Newton(),
-	           g_tol = 1e-12,
-	           iterations = 10,
-	           store_trace = true,
-	           show_trace = false)
-
-res = optimize(f3, g3!, h3!,
-	           [0.0, 0.0],
-	           method = SimulatedAnnealing(),
-	           iterations = 10,
-	           store_trace = true,
-	           show_trace = false)
-
+# Test multivariate optimization
 let
-    res = optimize(f3, g3!, h3!,
-    	           [0.0, 0.0],
+    rosenbrock = Optim.UnconstrainedProblems.examples["Rosenbrock"]
+    f = rosenbrock.f
+    g! = rosenbrock.g!
+    h! = rosenbrock.h!
+    initial_x = rosenbrock.initial_x
+
+    d1 = DifferentiableFunction(f)
+    d2 = DifferentiableFunction(f, g!)
+    d3 = TwiceDifferentiableFunction(f, g!, h!)
+
+    Optim.optimize(f, initial_x, BFGS())
+    Optim.optimize(f, g!, initial_x, BFGS())
+    Optim.optimize(f, g!, h!, initial_x, BFGS())
+    Optim.optimize(d2, initial_x, BFGS())
+    Optim.optimize(d3, initial_x, BFGS())
+
+    Optim.optimize(f, initial_x, BFGS(), OptimizationOptions())
+    Optim.optimize(f, g!, initial_x, BFGS(), OptimizationOptions())
+    Optim.optimize(f, g!, h!, initial_x, BFGS(), OptimizationOptions())
+    Optim.optimize(d2, initial_x, BFGS(), OptimizationOptions())
+    Optim.optimize(d3, initial_x, BFGS(), OptimizationOptions())
+
+    Optim.optimize(d1, initial_x, method = BFGS())
+    Optim.optimize(d2, initial_x, method = BFGS())
+
+    Optim.optimize(d1, initial_x, method = GradientDescent())
+    Optim.optimize(d2, initial_x, method = GradientDescent())
+
+    Optim.optimize(d1, initial_x, method = LBFGS())
+    Optim.optimize(d2, initial_x, method = LBFGS())
+
+    Optim.optimize(f, initial_x, method = NelderMead())
+
+    Optim.optimize(d3, initial_x, method = Newton())
+
+    Optim.optimize(f, initial_x, method = SimulatedAnnealing())
+
+    optimize(f, initial_x, method = BFGS())
+    optimize(f, initial_x, BFGS())
+    optimize(f, g!, initial_x, method = BFGS())
+    optimize(f, g!, h!, initial_x, method = BFGS())
+
+    optimize(f, initial_x, method = GradientDescent())
+    optimize(f, initial_x, GradientDescent())
+    optimize(f, g!, initial_x, method = GradientDescent())
+    optimize(f, g!, h!, initial_x, method = GradientDescent())
+
+    optimize(f, initial_x, method = LBFGS())
+    optimize(f, initial_x, LBFGS())
+    optimize(f, g!, initial_x, method = LBFGS())
+    optimize(f, g!, h!, initial_x, method = LBFGS())
+
+    optimize(f, initial_x, method = NelderMead())
+    optimize(f, initial_x, NelderMead())
+    optimize(f, g!, initial_x, method = NelderMead())
+    optimize(f, g!, h!, initial_x, method = NelderMead())
+
+    optimize(f, g!, h!, initial_x, method = Newton())
+
+    optimize(f, initial_x, method = SimulatedAnnealing())
+    optimize(f, initial_x, SimulatedAnnealing())
+    optimize(f, g!, initial_x, method = SimulatedAnnealing())
+    optimize(f, g!, h!, initial_x, method = SimulatedAnnealing())
+
+    res = optimize(f, g!, h!,
+    	           initial_x,
     	           method = BFGS(),
     	           g_tol = 1e-12,
     	           iterations = 10,
     	           store_trace = true,
     	           show_trace = false)
-   res_ext = optimize(f3, g3!, h3!,
-                      [0.0, 0.0],
+
+    res = optimize(f, g!, h!,
+    	           initial_x,
+    	           method = GradientDescent(),
+    	           g_tol = 1e-12,
+    	           iterations = 10,
+    	           store_trace = true,
+    	           show_trace = false)
+
+    res = optimize(f, g!, h!,
+    	           initial_x,
+    	           method = LBFGS(),
+    	           g_tol = 1e-12,
+    	           iterations = 10,
+    	           store_trace = true,
+    	           show_trace = false)
+
+    res = optimize(f, g!, h!,
+    	           initial_x,
+    	           method = NelderMead(),
+    	           f_tol = 1e-12,
+    	           iterations = 10,
+    	           store_trace = true,
+    	           show_trace = false)
+
+    res = optimize(f, g!, h!,
+    	           initial_x,
+    	           method = Newton(),
+    	           g_tol = 1e-12,
+    	           iterations = 10,
+    	           store_trace = true,
+    	           show_trace = false)
+
+    res = optimize(f, g!, h!,
+    	           initial_x,
+    	           method = SimulatedAnnealing(),
+    	           iterations = 10,
+    	           store_trace = true,
+    	           show_trace = false)
+
+    res = optimize(f, g!, h!,
+    	           initial_x,
+    	           method = BFGS(),
+    	           g_tol = 1e-12,
+    	           iterations = 10,
+    	           store_trace = true,
+    	           show_trace = false)
+   res_ext = optimize(f, g!, h!,
+                      initial_x,
                       method = BFGS(),
                       g_tol = 1e-12,
                       iterations = 10,
                       store_trace = true,
                       show_trace = false,
                       extended_trace = true)
+
    @test Optim.method(res) == "BFGS"
    @test Optim.minimum(res) ≈ 0.055119582904897345
    @test Optim.minimizer(res) ≈ [0.7731690866149542; 0.5917345966396391]
@@ -217,6 +143,7 @@ let
    @test Optim.iteration_limit_reached(res) == true
    @test Optim.initial_state(res) == [0.0; 0.0]
    @test haskey(Optim.trace(res_ext)[1].metadata,"x")
+
    # just testing if it runs
    Optim.trace(res)
    Optim.f_trace(res)
@@ -229,16 +156,17 @@ let
    @test_throws ErrorException Optim.rel_tol(res)
    @test_throws ErrorException Optim.abs_tol(res)
 
-   res_extended = Optim.optimize(f3, g3!, [0.0, 0.0], method=BFGS(), store_trace = true, extended_trace = true)
+   res_extended = Optim.optimize(f, g!, initial_x, method=BFGS(), store_trace = true, extended_trace = true)
    @test haskey(Optim.trace(res_extended)[1].metadata,"~inv(H)")
    @test haskey(Optim.trace(res_extended)[1].metadata,"g(x)")
    @test haskey(Optim.trace(res_extended)[1].metadata,"x")
 
-   res_extended_nm = Optim.optimize(f3, g3!, [0.0, 0.0], method=NelderMead(), store_trace = true, extended_trace = true)
+   res_extended_nm = Optim.optimize(f, g!, initial_x, method=NelderMead(), store_trace = true, extended_trace = true)
    @test haskey(Optim.trace(res_extended_nm)[1].metadata,"centroid")
    @test haskey(Optim.trace(res_extended_nm)[1].metadata,"step_type")
 end
 
+# Test univariate API
 let
     f(x) = 2x^2+3x+1
     res = optimize(f, -2.0, 1.0, method = GoldenSection())

--- a/test/array.jl
+++ b/test/array.jl
@@ -1,7 +1,4 @@
-module TestArray
-    using Optim
-    using Base.Test
-
+let
     f(X) = (10 - X[1, 1])^2 + (0 - X[1, 2])^2 + (0 - X[2, 1])^2 + (5 - X[2, 2])^2
 
     function g!(X, S)

--- a/test/backtracking_line_search.jl
+++ b/test/backtracking_line_search.jl
@@ -1,15 +1,17 @@
-f(x::Vector) = (1.0 - x[1])^2
-function g!(x::Vector, storage::Vector)
-	storage[1] = -2.0 * (1.0 - x[1])
+let
+	f(x::Vector) = (1.0 - x[1])^2
+	function g!(x::Vector, storage::Vector)
+		storage[1] = -2.0 * (1.0 - x[1])
+	end
+
+	x = [0.0]
+	gradient = [0.0]
+	ls_x = [0.0]
+	ls_gradient = [0.0]
+	g!(x, gradient)
+	dx = -gradient
+	d = DifferentiableFunction(f, g!)
+
+	t, f_up, g_up = Optim.backtracking_line_search!(d, x, dx, ls_x, ls_gradient)
+	@assert f(x + t * dx) < f(x) + 0.9 * t * -dot(gradient, dx)
 end
-
-x = [0.0]
-gradient = [0.0]
-ls_x = [0.0]
-ls_gradient = [0.0]
-g!(x, gradient)
-dx = -gradient
-d = DifferentiableFunction(f, g!)
-
-t, f_up, g_up = Optim.backtracking_line_search!(d, x, dx, ls_x, ls_gradient)
-@assert f(x + t * dx) < f(x) + 0.9 * t * -dot(gradient, dx)

--- a/test/bfgs.jl
+++ b/test/bfgs.jl
@@ -1,19 +1,11 @@
-function f2(x)
-  x[1]^2 + (2.0 - x[2])^2
+let
+    for use_autodiff in (false, true)
+        for (name, prob) in Optim.UnconstrainedProblems.examples
+            if prob.isdifferentiable
+                f_prob = prob.f
+                res = Optim.optimize(f_prob, prob.initial_x, BFGS(), OptimizationOptions(autodiff = use_autodiff))
+                @assert norm(res.minimum - prob.solutions) < 1e-2
+            end
+        end
+    end
 end
-function g2(x, storage)
-  storage[1] = 2.0 * x[1]
-  storage[2] = -2.0 * (2.0 - x[2])
-end
-d2 = DifferentiableFunction(f2, g2)
-initial_x = [100.0, 100.0]
-
-results = Optim.optimize(d2, initial_x, BFGS())
-@test_throws ErrorException Optim.trace(results)
-@assert Optim.g_converged(results)
-@assert norm(Optim.minimizer(results) - [0.0, 2.0]) < 0.01
-
-results = Optim.optimize(f2, initial_x, BFGS(), OptimizationOptions(autodiff = true))
-@test_throws ErrorException Optim.trace(results)
-@assert Optim.g_converged(results)
-@assert norm(Optim.minimizer(results) - [0.0, 2.0]) < 0.01

--- a/test/brent.jl
+++ b/test/brent.jl
@@ -1,6 +1,8 @@
-f_b(x) = 2x^2+3x+1
+let
+    for (name, prob) in Optim.UnivariateProblems.examples
+        results = optimize(prob.f, prob.bounds..., method = Brent())
 
-results = optimize(f_b, -2.0, 1.0, method = Brent())
-
-@assert Optim.converged(results)
-@assert abs(Optim.minimizer(results)+0.75) < 1e-7
+        @assert Optim.converged(results)
+        @assert norm(Optim.minimizer(results) - prob.minimizers) < 1e-7
+    end
+end

--- a/test/callbacks.jl
+++ b/test/callbacks.jl
@@ -1,58 +1,68 @@
+let
+    problem = Optim.UnconstrainedProblems.examples["Rosenbrock"]
 
-for method in (NelderMead(),
-               SimulatedAnnealing())
-    ot_run = false
-    cb = tr -> begin
-        @test tr.states[end].iteration % 3 == 0
-        ot_run = true
-    end
-    optimize(rosenbrock, [0.0,0,.0], method = method, callback = cb, show_every=3, store_trace=true)
-    @test ot_run == true
+    f = problem.f
+    g! = problem.g!
+    h! = problem.h!
+    initial_x = problem.initial_x
+    d2 = DifferentiableFunction(f, g!)
+    d3 = TwiceDifferentiableFunction(f, g!, h!)
 
-    os_run = false
-    cb = os -> begin
-        @test os.iteration % 3 == 0
-        os_run = true
-    end
-    optimize(rosenbrock, [0.0,0,.0], method = method, callback = cb, show_every=3)
-    @test os_run == true
-end
+    for method in (NelderMead(),
+                   SimulatedAnnealing())
+        ot_run = false
+        cb = tr -> begin
+            @test tr.states[end].iteration % 3 == 0
+            ot_run = true
+        end
+        optimize(f, initial_x, method = method, callback = cb, show_every=3, store_trace=true)
+        @test ot_run == true
 
-for method in (BFGS(),
-               ConjugateGradient(),
-               GradientDescent(),
-               MomentumGradientDescent())
-    ot_run = false
-    cb = tr -> begin
-        @test tr.states[end].iteration % 3 == 0
-        ot_run = true
+        os_run = false
+        cb = os -> begin
+            @test os.iteration % 3 == 0
+            os_run = true
+        end
+        optimize(f, initial_x, method = method, callback = cb, show_every=3)
+        @test os_run == true
     end
-    optimize(d2, [0.0,0,.0], method = method, callback = cb, show_every=3, store_trace=true)
-    @test ot_run == true
 
-    os_run = false
-    cb = os -> begin
-        @test os.iteration % 3 == 0
-        os_run = true
-    end
-    optimize(d2, [0.0,0,.0], method = method, callback = cb, show_every=3)
-    @test os_run == true
-end
+    for method in (BFGS(),
+                   ConjugateGradient(),
+                   GradientDescent(),
+                   MomentumGradientDescent())
+        ot_run = false
+        cb = tr -> begin
+            @test tr.states[end].iteration % 3 == 0
+            ot_run = true
+        end
+        optimize(d2, initial_x, method = method, callback = cb, show_every=3, store_trace=true)
+        @test ot_run == true
 
-for method in (Newton(),)
-    ot_run = false
-    cb = tr -> begin
-        @test tr.states[end].iteration % 3 == 0
-        ot_run = true
+        os_run = false
+        cb = os -> begin
+            @test os.iteration % 3 == 0
+            os_run = true
+        end
+        optimize(d2, initial_x, method = method, callback = cb, show_every=3)
+        @test os_run == true
     end
-    optimize(d3, [0.0,0.0], method = method, callback = cb, show_every=3, store_trace=true)
-    @test ot_run == true
 
-    os_run = false
-    cb = os -> begin
-        @test os.iteration % 3 == 0
-        os_run = true
+    for method in (Newton(),)
+        ot_run = false
+        cb = tr -> begin
+            @test tr.states[end].iteration % 3 == 0
+            ot_run = true
+        end
+        optimize(d3, initial_x, method = method, callback = cb, show_every=3, store_trace=true)
+        @test ot_run == true
+
+        os_run = false
+        cb = os -> begin
+            @test os.iteration % 3 == 0
+            os_run = true
+        end
+        optimize(d3, initial_x, method = method, callback = cb, show_every=3)
+        @test os_run == true
     end
-    optimize(d3, [0.0,0.0], method = method, callback = cb, show_every=3)
-    @test os_run == true
 end

--- a/test/cg.jl
+++ b/test/cg.jl
@@ -1,27 +1,27 @@
-using Optim
-
-# Test Optim.cg for all differentiable functions in Optim.UnconstrainedProblems.examples
-for (name, prob) in Optim.UnconstrainedProblems.examples
-	if prob.isdifferentiable
-		df = DifferentiableFunction(prob.f, prob.g!)
-		res = Optim.optimize(df, prob.initial_x, method=ConjugateGradient())
-			@assert norm(Optim.minimizer(res) - prob.solutions) < 1e-2
-	end
-end
-
 let
-objective(X, B) = sum((X.-B).^2)/2
+	# Test Optim.cg for all differentiable functions in Optim.UnconstrainedProblems.examples
+	for (name, prob) in Optim.UnconstrainedProblems.examples
+		if prob.isdifferentiable
+			df = DifferentiableFunction(prob.f, prob.g!)
+			res = Optim.optimize(df, prob.initial_x, method=ConjugateGradient())
+				@assert norm(Optim.minimizer(res) - prob.solutions) < 1e-2
+		end
+	end
 
-function objective_gradient!(X, G, B)
-    for i = 1:length(G)
-        G[i] = X[i]-B[i]
-    end
-end
+	let
+	objective(X, B) = sum((X.-B).^2)/2
 
-srand(1)
-B = rand(2,2)
-df = Optim.DifferentiableFunction(X -> objective(X, B), (X, G) -> objective_gradient!(X, G, B))
-results = Optim.optimize(df, rand(2,2), method=ConjugateGradient())
-@assert Optim.converged(results)
-@assert Optim.minimum(results) < 1e-8
+	function objective_gradient!(X, G, B)
+	    for i = 1:length(G)
+	        G[i] = X[i]-B[i]
+	    end
+	end
+
+	srand(1)
+	B = rand(2,2)
+	df = Optim.DifferentiableFunction(X -> objective(X, B), (X, G) -> objective_gradient!(X, G, B))
+	results = Optim.optimize(df, rand(2,2), method=ConjugateGradient())
+	@assert Optim.converged(results)
+	@assert Optim.minimum(results) < 1e-8
+	end
 end

--- a/test/constrained.jl
+++ b/test/constrained.jl
@@ -1,64 +1,63 @@
-import Optim
-using Base.Test
+let
+    # Quadratic objective function
+    # For (A*x-b)^2/2
+    function quadratic!(x, g, AtA, Atb, tmp)
+        calc_grad = !(g === nothing)
+        A_mul_B!(tmp, AtA, x)
+        v = dot(x,tmp)/2 + dot(Atb,x)
+        if calc_grad
+            for i = 1:length(g)
+                g[i] = tmp[i] + Atb[i]
+            end
+        end
+        return v
+    end
 
-# Quadratic objective function
-# For (A*x-b)^2/2
-function quadratic!(x, g, AtA, Atb, tmp)
-    calc_grad = !(g === nothing)
-    A_mul_B!(tmp, AtA, x)
-    v = dot(x,tmp)/2 + dot(Atb,x)
-    if calc_grad
-        for i = 1:length(g)
-            g[i] = tmp[i] + Atb[i]
+    srand(1)
+    N = 8
+    boxl = 2.0
+    outbox = false
+    # Generate a problem where the bounds-free solution lies outside of the chosen box
+    global objective
+    while !outbox
+        A = randn(N,N)
+        AtA = A'*A
+        b = randn(N)
+        initial_x = randn(N)
+        tmp = similar(initial_x)
+        func = (x, g) -> quadratic!(x, g, AtA, A'*b, tmp)
+        objective = Optim.DifferentiableFunction(x->func(x, nothing), (x,g)->func(x,g), func)
+        results = Optim.optimize(objective, initial_x, method=ConjugateGradient())
+        results = Optim.optimize(objective, results.minimum, method=ConjugateGradient())  # restart to ensure high-precision convergence
+        @test Optim.converged(results)
+        g = similar(initial_x)
+        @test func(results.minimum, g) + dot(b,b)/2 < 1e-8
+        @test norm(g) < 1e-4
+        outbox = any(abs(results.minimum) .> boxl)
+    end
+
+    # fminbox
+    l = fill(-boxl, N)
+    u = fill(boxl, N)
+    initial_x = (rand(N)-0.5)*boxl
+    for _optimizer in (ConjugateGradient, GradientDescent, LBFGS, BFGS)
+        results = Optim.optimize(objective, initial_x, l, u, Fminbox(), optimizer = _optimizer)
+        @test Optim.converged(results)
+
+        g = similar(initial_x)
+        objective.fg!(Optim.minimizer(results), g)
+        for i = 1:N
+            @test abs(g[i]) < 3e-3 || (Optim.minimizer(results)[i] < -boxl+1e-3 && g[i] > 0) || (Optim.minimizer(results)[i] > boxl-1e-3 && g[i] < 0)
         end
     end
-    return v
+
+    # tests for #180
+    results = Optim.optimize(objective, initial_x, l, u, Fminbox(); iterations = 2)
+    @test results.iterations == 2
+    @test results.f_minimum == objective.f(results.minimum)
+
+    # might fail if changes are made to Optim.jl
+    # TODO: come up with a better test
+    results = Optim.optimize(objective, initial_x, l, u, Fminbox(); optimizer_o = OptimizationOptions(iterations = 2))
+    @test results.iterations == 470
 end
-
-srand(1)
-N = 8
-boxl = 2.0
-outbox = false
-# Generate a problem where the bounds-free solution lies outside of the chosen box
-global objective
-while !outbox
-    A = randn(N,N)
-    AtA = A'*A
-    b = randn(N)
-    initial_x = randn(N)
-    tmp = similar(initial_x)
-    func = (x, g) -> quadratic!(x, g, AtA, A'*b, tmp)
-    objective = Optim.DifferentiableFunction(x->func(x, nothing), (x,g)->func(x,g), func)
-    results = Optim.optimize(objective, initial_x, method=ConjugateGradient())
-    results = Optim.optimize(objective, results.minimum, method=ConjugateGradient())  # restart to ensure high-precision convergence
-    @test Optim.converged(results)
-    g = similar(initial_x)
-    @test func(results.minimum, g) + dot(b,b)/2 < 1e-8
-    @test norm(g) < 1e-4
-    outbox = any(abs(results.minimum) .> boxl)
-end
-
-# fminbox
-l = fill(-boxl, N)
-u = fill(boxl, N)
-initial_x = (rand(N)-0.5)*boxl
-for _optimizer in (ConjugateGradient, GradientDescent, LBFGS, BFGS)
-    results = Optim.optimize(objective, initial_x, l, u, Fminbox(), optimizer = _optimizer)
-    @test Optim.converged(results)
-
-    g = similar(initial_x)
-    objective.fg!(Optim.minimizer(results), g)
-    for i = 1:N
-        @test abs(g[i]) < 3e-3 || (Optim.minimizer(results)[i] < -boxl+1e-3 && g[i] > 0) || (Optim.minimizer(results)[i] > boxl-1e-3 && g[i] < 0)
-    end
-end
-
-# tests for #180
-results = Optim.optimize(objective, initial_x, l, u, Fminbox(); iterations = 2)
-@test results.iterations == 2
-@test results.f_minimum == objective.f(results.minimum)
-
-# might fail if changes are made to Optim.jl
-# TODO: come up with a better test
-results = Optim.optimize(objective, initial_x, l, u, Fminbox(); optimizer_o = OptimizationOptions(iterations = 2))
-@test results.iterations == 470

--- a/test/golden_section.jl
+++ b/test/golden_section.jl
@@ -1,6 +1,8 @@
-f(x) = 2x^2+3x+1
+let
+    for (name, prob) in Optim.UnivariateProblems.examples
+        results = optimize(prob.f, prob.bounds..., method = GoldenSection())
 
-results = optimize(f, -2.0, 1.0, method = GoldenSection())
-
-@assert Optim.converged(results)
-@assert abs(Optim.minimizer(results)+0.75) < 1e-7
+        @assert Optim.converged(results)
+        @assert norm(Optim.minimizer(results) - prob.minimizers) < 1e-7
+    end
+end

--- a/test/gradient_descent.jl
+++ b/test/gradient_descent.jl
@@ -1,34 +1,55 @@
-function f_gd_1(x)
-  (x[1] - 5.0)^2
+let
+    for use_autodiff in (false, true)
+        for (name, prob) in Optim.UnconstrainedProblems.examples
+            if prob.isdifferentiable
+                f_prob = prob.f
+                iterations = if name == "Rosenbrock"
+                        5000 # Zig-zagging
+                    elseif name == "Powell"
+                        80000 # Zig-zagging as the problem is (intentionally) ill-conditioned
+                    else
+                        1000
+                end
+                res = Optim.optimize(f_prob, prob.initial_x, GradientDescent(),
+                                     OptimizationOptions(autodiff = use_autodiff,
+                                                         iterations = iterations))
+                @assert norm(res.minimum - prob.solutions, Inf) < 1e-2
+            end
+        end
+    end
+
+    function f_gd_1(x)
+      (x[1] - 5.0)^2
+    end
+
+    function g_gd_1(x, storage)
+      storage[1] = 2.0 * (x[1] - 5.0)
+    end
+
+    initial_x = [0.0]
+
+    d = DifferentiableFunction(f_gd_1, g_gd_1)
+
+    results = Optim.optimize(d, initial_x, method=GradientDescent())
+    @test_throws ErrorException Optim.x_trace(results)
+    @assert Optim.g_converged(results)
+    @assert norm(Optim.minimizer(results) - [5.0]) < 0.01
+
+    eta = 0.9
+
+    function f_gd_2(x)
+      (1.0 / 2.0) * (x[1]^2 + eta * x[2]^2)
+    end
+
+    function g_gd_2(x, storage)
+      storage[1] = x[1]
+      storage[2] = eta * x[2]
+    end
+
+    d = DifferentiableFunction(f_gd_2, g_gd_2)
+
+    results = Optim.optimize(d, [1.0, 1.0], method=GradientDescent())
+    @test_throws ErrorException Optim.x_trace(results)
+    @assert Optim.g_converged(results)
+    @assert norm(Optim.minimizer(results) - [0.0, 0.0]) < 0.01
 end
-
-function g_gd_1(x, storage)
-  storage[1] = 2.0 * (x[1] - 5.0)
-end
-
-initial_x = [0.0]
-
-d = DifferentiableFunction(f_gd_1, g_gd_1)
-
-results = Optim.optimize(d, initial_x, method=GradientDescent())
-@test_throws ErrorException Optim.x_trace(results)
-@assert Optim.g_converged(results)
-@assert norm(Optim.minimizer(results) - [5.0]) < 0.01
-
-eta = 0.9
-
-function f_gd_2(x)
-  (1.0 / 2.0) * (x[1]^2 + eta * x[2]^2)
-end
-
-function g_gd_2(x, storage)
-  storage[1] = x[1]
-  storage[2] = eta * x[2]
-end
-
-d = DifferentiableFunction(f_gd_2, g_gd_2)
-
-results = Optim.optimize(d, [1.0, 1.0], method=GradientDescent())
-@test_throws ErrorException Optim.x_trace(results)
-@assert Optim.g_converged(results)
-@assert norm(Optim.minimizer(results) - [0.0, 0.0]) < 0.01

--- a/test/interpolating_line_search.jl
+++ b/test/interpolating_line_search.jl
@@ -1,25 +1,27 @@
-f5(x) = (x[1] - 5.0)^2 + (x[2] - 11.0)^2
-function g5!(x, storage)
-	storage[1] = 2.0 * (x[1] - 5.0)
-	storage[2] = 2.0 * (x[2] - 11.0)
+let
+	f5(x) = (x[1] - 5.0)^2 + (x[2] - 11.0)^2
+	function g5!(x, storage)
+		storage[1] = 2.0 * (x[1] - 5.0)
+		storage[2] = 2.0 * (x[2] - 11.0)
+	end
+	d = DifferentiableFunction(f5, g5!)
+
+	x = [0.0, 0.0]
+	x_new = [0.0, 0.0]
+	gr_new = [0.0, 0.0]
+	phi0 = d.fg!(x, gr_new)
+	p = -gr_new
+	dphi0 = dot(p, gr_new)
+
+	lsr = Optim.LineSearchResults(eltype(x))
+	push!(lsr, 0.0, phi0, dphi0)
+
+	alpha = 1.0
+	mayterminate = false
+	alpha, f_update, g_update = Optim.backtracking_linesearch!(d, x, p, x_new, gr_new, lsr, alpha, mayterminate)
+	alpha, f_update, g_update = Optim.interpolating_linesearch!(d, x, p, x_new, gr_new, lsr, alpha, mayterminate)
+	alpha, f_update, g_update = Optim.mt_linesearch!(d, x, p, x_new, gr_new, lsr, alpha, mayterminate)
+	alpha, f_update, g_update = Optim.hz_linesearch!(d, x, p, x_new, gr_new, lsr, alpha, mayterminate)
+
+	Optim.optimize(d, [0.0, 0.0], method=LBFGS())
 end
-d = DifferentiableFunction(f5, g5!)
-
-x = [0.0, 0.0]
-x_new = [0.0, 0.0]
-gr_new = [0.0, 0.0]
-phi0 = d.fg!(x, gr_new)
-p = -gr_new
-dphi0 = dot(p, gr_new)
-
-lsr = Optim.LineSearchResults(eltype(x))
-push!(lsr, 0.0, phi0, dphi0)
-
-alpha = 1.0
-mayterminate = false
-alpha, f_update, g_update = Optim.backtracking_linesearch!(d, x, p, x_new, gr_new, lsr, alpha, mayterminate)
-alpha, f_update, g_update = Optim.interpolating_linesearch!(d, x, p, x_new, gr_new, lsr, alpha, mayterminate)
-alpha, f_update, g_update = Optim.mt_linesearch!(d, x, p, x_new, gr_new, lsr, alpha, mayterminate)
-alpha, f_update, g_update = Optim.hz_linesearch!(d, x, p, x_new, gr_new, lsr, alpha, mayterminate)
-
-Optim.optimize(d, [0.0, 0.0], method=LBFGS())

--- a/test/l_bfgs.jl
+++ b/test/l_bfgs.jl
@@ -1,18 +1,11 @@
-function f(x::Vector)
-  (309.0 - 5.0 * x[1])^2 + (17.0 - x[2])^2
+let
+    for use_autodiff in (false, true)
+        for (name, prob) in Optim.UnconstrainedProblems.examples
+            if prob.isdifferentiable
+                f_prob = prob.f
+                res = Optim.optimize(f_prob, prob.initial_x, LBFGS(), OptimizationOptions(autodiff = use_autodiff))
+                @assert norm(res.minimum - prob.solutions) < 1e-2
+            end
+        end
+    end
 end
-function g!(x::Vector, storage::Vector)
-  storage[1] = -10.0 * (309.0 - 5.0 * x[1])
-  storage[2] = -2.0 * (17.0 - x[2])
-end
-
-d = DifferentiableFunction(f, g!)
-
-initial_x = [10.0, 10.0]
-m = 10
-store_trace, show_trace = false, false
-
-results = Optim.optimize(d, initial_x, method=LBFGS())
-@test_throws ErrorException Optim.x_trace(results)
-@assert Optim.g_converged(results)
-@assert norm(Optim.minimizer(results) - [309.0 / 5.0, 17.0]) < 0.01

--- a/test/levenberg_marquardt.jl
+++ b/test/levenberg_marquardt.jl
@@ -1,84 +1,86 @@
-function f_lm(x)
-  [x[1], 2.0 - x[2]]
-end
-function g_lm(x)
-  [1.0 0.0; 0.0 -1.0]
-end
-
-initial_x = [100.0, 100.0]
-
-results = Optim.levenberg_marquardt(f_lm, g_lm, initial_x)
-@assert norm(Optim.minimizer(results) - [0.0, 2.0]) < 0.01
-
-
-function rosenbrock_res(x, r)
-    r[1] = 10.0 * (x[2] - x[1]^2 )
-    r[2] =  1.0 - x[1]
-    return r
-end
-
-function rosenbrock_jac(x, j)
-    j[1, 1] = -20.0 * x[1]
-    j[1, 2] =  10.0
-    j[2, 1] =  -1.0
-    j[2, 2] =   0.0
-    return j
-end
-
-r = zeros(2)
-j = zeros(2,2)
-
-frb(x) = rosenbrock_res(x, r)
-grb(x) = rosenbrock_jac(x, j)
-
-initial_xrb = [-1.2, 1.0]
-
-results = Optim.levenberg_marquardt(frb, grb, initial_xrb)
-
-@assert norm(Optim.minimizer(results) - [1.0, 1.0]) < 0.01
-
-# tests for #178, taken from LsqFit.jl, but stripped
 let
-    srand(12345)
+    function f_lm(x)
+      [x[1], 2.0 - x[2]]
+    end
+    function g_lm(x)
+      [1.0 0.0; 0.0 -1.0]
+    end
 
-    model(x, p) = p[1]*exp(-x.*p[2])
+    initial_x = [100.0, 100.0]
 
-    xdata = linspace(0,10,20)
-    ydata = model(xdata, [1.0 2.0]) + 0.01*randn(length(xdata))
+    results = Optim.levenberg_marquardt(f_lm, g_lm, initial_x)
+    @assert norm(Optim.minimizer(results) - [0.0, 2.0]) < 0.01
 
-    f_lsq = p -> p[1]*exp(-xdata.*p[2])-ydata
-    g_lsq = Calculus.jacobian(f_lsq)
-    results = Optim.levenberg_marquardt(f_lsq, g_lsq, [0.5, 0.5])
 
-    @assert norm(Optim.minimizer(results) - [1.0, 2.0]) < 0.05
-end
+    function rosenbrock_res(x, r)
+        r[1] = 10.0 * (x[2] - x[1]^2 )
+        r[2] =  1.0 - x[1]
+        return r
+    end
 
-# tests for box constraints, PR #196
-let
-    srand(12345)
+    function rosenbrock_jac(x, j)
+        j[1, 1] = -20.0 * x[1]
+        j[1, 2] =  10.0
+        j[2, 1] =  -1.0
+        j[2, 2] =   0.0
+        return j
+    end
 
-    model(x, p) = p[1]*exp(-x./p[2])+p[3]
+    r = zeros(2)
+    j = zeros(2,2)
 
-    xdata = 1:100
-    ydata = model(xdata, [10.0, 10.0, 10.0]) + 0.1*randn(length(xdata))
+    frb(x) = rosenbrock_res(x, r)
+    grb(x) = rosenbrock_jac(x, j)
 
-    f_lsq = p -> model(xdata,p)-ydata
-    g_lsq = Calculus.jacobian(f_lsq)
+    initial_xrb = [-1.2, 1.0]
 
-    @test_throws ArgumentError Optim.levenberg_marquardt(f_lsq, g_lsq, [15.0, 15.0, 15.0], lower=[5.0, 11.0])
-    @test_throws ArgumentError Optim.levenberg_marquardt(f_lsq, g_lsq, [5.0, 5.0, 5.0], upper=[15.0, 9.0])
-    @test_throws ArgumentError Optim.levenberg_marquardt(f_lsq, g_lsq, [15.0, 10.0, 15.0], lower=[5.0, 11.0, 5.0])
-    @test_throws ArgumentError Optim.levenberg_marquardt(f_lsq, g_lsq, [5.0, 10.0, 5.0], upper=[15.0, 9.0, 15.0])
+    results = Optim.levenberg_marquardt(frb, grb, initial_xrb)
 
-    lower=[5.0, 11.0, 5.0]
-    results = Optim.levenberg_marquardt(f_lsq, g_lsq, [15.0, 15.0, 15.0], lower=lower)
-    Optim.minimizer(results)
-    @test Optim.converged(results)
-    @test all(Optim.minimizer(results) .>= lower)
+    @assert norm(Optim.minimizer(results) - [1.0, 1.0]) < 0.01
 
-    upper=[15.0, 9.0, 15.0]
-    results = Optim.levenberg_marquardt(f_lsq, g_lsq, [5.0, 5.0, 5.0], upper=upper)
-    Optim.minimizer(results)
-    @test Optim.converged(results)
-    @test all(Optim.minimizer(results) .<= upper)
+    # tests for #178, taken from LsqFit.jl, but stripped
+    let
+        srand(12345)
+
+        model(x, p) = p[1]*exp(-x.*p[2])
+
+        xdata = linspace(0,10,20)
+        ydata = model(xdata, [1.0 2.0]) + 0.01*randn(length(xdata))
+
+        f_lsq = p -> p[1]*exp(-xdata.*p[2])-ydata
+        g_lsq = Calculus.jacobian(f_lsq)
+        results = Optim.levenberg_marquardt(f_lsq, g_lsq, [0.5, 0.5])
+
+        @assert norm(Optim.minimizer(results) - [1.0, 2.0]) < 0.05
+    end
+
+    # tests for box constraints, PR #196
+    let
+        srand(12345)
+
+        model(x, p) = p[1]*exp(-x./p[2])+p[3]
+
+        xdata = 1:100
+        ydata = model(xdata, [10.0, 10.0, 10.0]) + 0.1*randn(length(xdata))
+
+        f_lsq = p -> model(xdata,p)-ydata
+        g_lsq = Calculus.jacobian(f_lsq)
+
+        @test_throws ArgumentError Optim.levenberg_marquardt(f_lsq, g_lsq, [15.0, 15.0, 15.0], lower=[5.0, 11.0])
+        @test_throws ArgumentError Optim.levenberg_marquardt(f_lsq, g_lsq, [5.0, 5.0, 5.0], upper=[15.0, 9.0])
+        @test_throws ArgumentError Optim.levenberg_marquardt(f_lsq, g_lsq, [15.0, 10.0, 15.0], lower=[5.0, 11.0, 5.0])
+        @test_throws ArgumentError Optim.levenberg_marquardt(f_lsq, g_lsq, [5.0, 10.0, 5.0], upper=[15.0, 9.0, 15.0])
+
+        lower=[5.0, 11.0, 5.0]
+        results = Optim.levenberg_marquardt(f_lsq, g_lsq, [15.0, 15.0, 15.0], lower=lower)
+        Optim.minimizer(results)
+        @test Optim.converged(results)
+        @test all(Optim.minimizer(results) .>= lower)
+
+        upper=[15.0, 9.0, 15.0]
+        results = Optim.levenberg_marquardt(f_lsq, g_lsq, [5.0, 5.0, 5.0], upper=upper)
+        Optim.minimizer(results)
+        @test Optim.converged(results)
+        @test all(Optim.minimizer(results) .<= upper)
+    end
 end

--- a/test/momentum_gradient_descent.jl
+++ b/test/momentum_gradient_descent.jl
@@ -1,9 +1,19 @@
-p = Optim.UnconstrainedProblems.examples["Rosenbrock"]
-
-df = DifferentiableFunction(p.f, p.g!)
-
-Optim.optimize(df, [0.0, 0.0], method=MomentumGradientDescent())
-
-Optim.optimize(df, [0.0, 0.0], method=MomentumGradientDescent(mu = 0.1))
-
-optimize(p.f, p.g!, [0.0, 0.0])
+debug = false
+let
+    for use_autodiff in (false, true)
+        for (name, prob) in Optim.UnconstrainedProblems.examples
+            if prob.isdifferentiable && !(name in ("Polynomial", "Large Polynomial", "Himmelblau")) # it goes in a direction of ascent -> f_converged == true
+                debug && @ show "** Name: $name"
+                f_prob = prob.f
+                iterations = name == "Powell" ? 2000 : 1000
+                res = Optim.optimize(f_prob, prob.initial_x, MomentumGradientDescent(),
+                                     OptimizationOptions(autodiff = use_autodiff,
+                                                         iterations = iterations,
+                                                         show_trace = debug))
+                debug && @show res.minimum
+                debug && @show prob.solutions
+                @assert norm(res.minimum - prob.solutions, Inf) < 1e-2
+            end
+        end
+    end
+end

--- a/test/nelder_mead.jl
+++ b/test/nelder_mead.jl
@@ -1,35 +1,13 @@
-using Optim
-
-# Test Optim.nelder_mead for all functions except Large Polynomials in Optim.UnconstrainedProblems.examples
-for (name, prob) in Optim.UnconstrainedProblems.examples
-	f_prob = prob.f
-	res = Optim.optimize(f_prob, prob.initial_x, NelderMead(), OptimizationOptions(iterations = 10000))
-	if name == "Powell"
-		res = Optim.optimize(f_prob, prob.initial_x, method=NelderMead(), g_tol = 1e-12)
-	elseif name == "Large Polynomial"
-		res = Optim.optimize(f_prob, prob.initial_x, method=NelderMead(initial_simplex = Optim.AffineSimplexer(1.,1.)), iterations = 500_000)
+let
+	# Test Optim.nelder_mead for all functions except Large Polynomials in Optim.UnconstrainedProblems.examples
+	for (name, prob) in Optim.UnconstrainedProblems.examples
+		f_prob = prob.f
+		res = Optim.optimize(f_prob, prob.initial_x, NelderMead(), OptimizationOptions(iterations = 10000))
+		if name == "Powell"
+			res = Optim.optimize(f_prob, prob.initial_x, method=NelderMead(), g_tol = 1e-12)
+		elseif name == "Large Polynomial"
+			res = Optim.optimize(f_prob, prob.initial_x, method=NelderMead(initial_simplex = Optim.AffineSimplexer(1.,1.)), iterations = 500_000)
+		end
+		@assert norm(res.minimum - prob.solutions) < 1e-2
 	end
-	@assert norm(res.minimum - prob.solutions) < 1e-2
 end
-
-function f_nm(x::Vector)
-  (100.0 - x[1])^2 + x[2]^2
-end
-
-function rosenbrock_nm(x::Vector)
-  (1.0 - x[1])^2 + 100.0 * (x[2] - x[1]^2)^2
-end
-
-initial_x = [0.0, 0.0]
-
-results = Optim.optimize(f_nm, initial_x, method=NelderMead())
-
-@assert Optim.g_converged(results)
-@assert norm(Optim.minimizer(results) - [100.0, 0.0]) < 0.01
-@test_throws ErrorException Optim.x_trace(results)
-
-results = Optim.optimize(rosenbrock_nm, initial_x, method=NelderMead())
-
-@assert Optim.g_converged(results)
-@assert norm(Optim.minimizer(results) - [1.0, 1.0]) < 0.01
-@test_throws ErrorException Optim.x_trace(results)

--- a/test/newton.jl
+++ b/test/newton.jl
@@ -1,78 +1,77 @@
-using Optim
-using Base.Test
-
-function f_1(x::Vector)
-    (x[1] - 5.0)^4
-end
-
-function g!_1(x::Vector, storage::Vector)
-    storage[1] = 4.0 * (x[1] - 5.0)^3
-end
-
-function h!_1(x::Vector, storage::Matrix)
-    storage[1, 1] = 12.0 * (x[1] - 5.0)^2
-end
-
-d = TwiceDifferentiableFunction(f_1, g!_1, h!_1)
-
-# Need to specify autodiff!
-@test_throws ErrorException Optim.optimize(DifferentiableFunction(f_1, g!_1), [0.0], Newton())
-Optim.optimize(DifferentiableFunction(f_1, g!_1), [0.0], Newton(), OptimizationOptions(autodiff = true))
-
-results = Optim.optimize(d, [0.0], Newton())
-@test_throws ErrorException Optim.x_trace(results)
-@assert Optim.g_converged(results)
-@assert norm(Optim.minimizer(results) - [5.0]) < 0.01
-
-eta = 0.9
-
-function f_2(x::Vector)
-  (1.0 / 2.0) * (x[1]^2 + eta * x[2]^2)
-end
-
-function g!_2(x::Vector, storage::Vector)
-  storage[1] = x[1]
-  storage[2] = eta * x[2]
-end
-
-function h!_2(x::Vector, storage::Matrix)
-  storage[1, 1] = 1.0
-  storage[1, 2] = 0.0
-  storage[2, 1] = 0.0
-  storage[2, 2] = eta
-end
-
-d = TwiceDifferentiableFunction(f_2, g!_2, h!_2)
-results = Optim.optimize(d, [127.0, 921.0], method=Newton())
-@test_throws ErrorException Optim.x_trace(results)
-@assert Optim.g_converged(results)
-@assert norm(Optim.minimizer(results) - [0.0, 0.0]) < 0.01
-
-# Test Optim.newton for all twice differentiable functions in Optim.UnconstrainedProblems.examples
-for (name, prob) in Optim.UnconstrainedProblems.examples
-	if prob.istwicedifferentiable
-		ddf = TwiceDifferentiableFunction(prob.f, prob.g!,prob.h!)
-		res = Optim.optimize(ddf, prob.initial_x, method=Newton())
-		@assert norm(Optim.minimizer(res) - prob.solutions) < 1e-2
-	end
-end
-
 let
-    prob=Optim.UnconstrainedProblems.examples["Himmelblau"]
-    ddf = TwiceDifferentiableFunction(prob.f, prob.g!, prob.h!)
-    res = optimize(ddf, [0., 0.], Newton())
-    @assert norm(res.minimum - prob.solutions) < 1e-10
-end
+    function f_1(x::Vector)
+        (x[1] - 5.0)^4
+    end
+
+    function g!_1(x::Vector, storage::Vector)
+        storage[1] = 4.0 * (x[1] - 5.0)^3
+    end
+
+    function h!_1(x::Vector, storage::Matrix)
+        storage[1, 1] = 12.0 * (x[1] - 5.0)^2
+    end
+
+    d = TwiceDifferentiableFunction(f_1, g!_1, h!_1)
+
+    # Need to specify autodiff!
+    @test_throws ErrorException Optim.optimize(DifferentiableFunction(f_1, g!_1), [0.0], Newton())
+    Optim.optimize(DifferentiableFunction(f_1, g!_1), [0.0], Newton(), OptimizationOptions(autodiff = true))
+
+    results = Optim.optimize(d, [0.0], Newton())
+    @test_throws ErrorException Optim.x_trace(results)
+    @assert Optim.g_converged(results)
+    @assert norm(Optim.minimizer(results) - [5.0]) < 0.01
+
+    eta = 0.9
+
+    function f_2(x::Vector)
+      (1.0 / 2.0) * (x[1]^2 + eta * x[2]^2)
+    end
+
+    function g!_2(x::Vector, storage::Vector)
+      storage[1] = x[1]
+      storage[2] = eta * x[2]
+    end
+
+    function h!_2(x::Vector, storage::Matrix)
+      storage[1, 1] = 1.0
+      storage[1, 2] = 0.0
+      storage[2, 1] = 0.0
+      storage[2, 2] = eta
+    end
+
+    d = TwiceDifferentiableFunction(f_2, g!_2, h!_2)
+    results = Optim.optimize(d, [127.0, 921.0], method=Newton())
+    @test_throws ErrorException Optim.x_trace(results)
+    @assert Optim.g_converged(results)
+    @assert norm(Optim.minimizer(results) - [0.0, 0.0]) < 0.01
+
+    # Test Optim.newton for all twice differentiable functions in Optim.UnconstrainedProblems.examples
+    for (name, prob) in Optim.UnconstrainedProblems.examples
+    	if prob.istwicedifferentiable
+    		ddf = TwiceDifferentiableFunction(prob.f, prob.g!,prob.h!)
+    		res = Optim.optimize(ddf, prob.initial_x, method=Newton())
+    		@assert norm(Optim.minimizer(res) - prob.solutions) < 1e-2
+    	end
+    end
+
+    let
+        prob=Optim.UnconstrainedProblems.examples["Himmelblau"]
+        ddf = TwiceDifferentiableFunction(prob.f, prob.g!, prob.h!)
+        res = optimize(ddf, [0., 0.], Newton())
+        @assert norm(res.minimum - prob.solutions) < 1e-10
+    end
 
 
-for (name, prob) in Optim.UnconstrainedProblems.examples
-	if prob.istwicedifferentiable
-		ddf = DifferentiableFunction(prob.f, prob.g!)
-		res = Optim.optimize(ddf, prob.initial_x, Newton(), OptimizationOptions(autodiff = true))
-		@assert norm(Optim.minimizer(res) - prob.solutions) < 1e-2
-		res = Optim.optimize(ddf.f, prob.initial_x, Newton(), OptimizationOptions(autodiff = true))
-		@assert norm(Optim.minimizer(res) - prob.solutions) < 1e-2
-        res = Optim.optimize(ddf.f, ddf.g!, prob.initial_x, Newton(), OptimizationOptions(autodiff = true))
-		@assert norm(Optim.minimizer(res) - prob.solutions) < 1e-2
-	end
+    for (name, prob) in Optim.UnconstrainedProblems.examples
+    	if prob.istwicedifferentiable
+    		ddf = DifferentiableFunction(prob.f, prob.g!)
+    		res = Optim.optimize(ddf, prob.initial_x, Newton(), OptimizationOptions(autodiff = true))
+    		@assert norm(Optim.minimizer(res) - prob.solutions) < 1e-2
+    		res = Optim.optimize(ddf.f, prob.initial_x, Newton(), OptimizationOptions(autodiff = true))
+    		@assert norm(Optim.minimizer(res) - prob.solutions) < 1e-2
+            res = Optim.optimize(ddf.f, ddf.g!, prob.initial_x, Newton(), OptimizationOptions(autodiff = true))
+    		@assert norm(Optim.minimizer(res) - prob.solutions) < 1e-2
+    	end
+    end
 end

--- a/test/newton_trust_region.jl
+++ b/test/newton_trust_region.jl
@@ -1,152 +1,150 @@
-using Optim
-using Base.Test
+let
+    #######################################
+    # First test the subproblem.
+    srand(42)
+    n = 5
+    H = rand(n, n)
+    H = H' * H + 4 * eye(n)
+    H_eig = eigfact(H)
+    U = H_eig[:vectors]
+
+    gr = zeros(n)
+    gr[1] = 1.
+    s = zeros(Float64, n)
+
+    true_s = -H \ gr
+    s_norm2 = dot(true_s, true_s)
+    true_m = dot(true_s, gr) + 0.5 * dot(true_s, H * true_s)
+
+    # An interior solution
+    delta = sqrt(s_norm2) + 1.0
+    m, interior, lambda, hard_case, reached_solution =
+        Optim.solve_tr_subproblem!(gr, H, delta, s)
+    @assert interior
+    @assert !hard_case
+    @assert reached_solution
+    @assert abs(m - true_m) < 1e-12
+    @assert norm(s - true_s) < 1e-12
+    @assert abs(lambda) < 1e-12
+
+    # A boundary solution
+    delta = 0.5 * sqrt(s_norm2)
+    m, interior, lambda, hard_case, reached_solution =
+        Optim.solve_tr_subproblem!(gr, H, delta, s)
+    @assert !interior
+    @assert !hard_case
+    @assert reached_solution
+    @assert m > true_m
+    @assert abs(norm(s) - delta) < 1e-12
+    @assert lambda > 0
+
+    # A "hard case" where the gradient is orthogonal to the lowest eigenvector
+
+    # Test the checking
+    hard_case, lambda_1_multiplicity =
+        Optim.check_hard_case_candidate([-1., 2., 3.], [0., 1., 1.])
+    @assert hard_case
+    @assert lambda_1_multiplicity == 1
+
+    hard_case, lambda_1_multiplicity =
+        Optim.check_hard_case_candidate([-1., -1., 3.], [0., 0., 1.])
+    @assert hard_case
+    @assert lambda_1_multiplicity == 2
+
+    hard_case, lambda_1_multiplicity =
+        Optim.check_hard_case_candidate([-1., -1., -1.], [0., 0., 0.])
+    @assert hard_case
+    @assert lambda_1_multiplicity == 3
+
+    hard_case, lambda_1_multiplicity =
+        Optim.check_hard_case_candidate([1., 2., 3.], [0., 1., 1.])
+    @assert !hard_case
+
+    hard_case, lambda_1_multiplicity =
+        Optim.check_hard_case_candidate([-1., -1., -1.], [0., 0., 1.])
+    @assert !hard_case
+
+    hard_case, lambda_1_multiplicity =
+        Optim.check_hard_case_candidate([-1., 2., 3.], [1., 1., 1.])
+    @assert !hard_case
 
 
-#######################################
-# First test the subproblem.
-srand(42)
-n = 5
-H = rand(n, n)
-H = H' * H + 4 * eye(n)
-H_eig = eigfact(H)
-U = H_eig[:vectors]
+    # Now check an actual had case problem
+    L = zeros(Float64, n) + 0.1
+    L[1] = -1.
+    H = U * diagm(L) * U'
+    H = 0.5 * (H' + H)
+    @assert issymmetric(H)
+    gr = U[:,2][:]
+    @assert abs(dot(gr, U[:,1][:])) < 1e-12
+    true_s = -H \ gr
+    s_norm2 = dot(true_s, true_s)
+    true_m = dot(true_s, gr) + 0.5 * dot(true_s, H * true_s)
 
-gr = zeros(n)
-gr[1] = 1.
-s = zeros(Float64, n)
-
-true_s = -H \ gr
-s_norm2 = dot(true_s, true_s)
-true_m = dot(true_s, gr) + 0.5 * dot(true_s, H * true_s)
-
-# An interior solution
-delta = sqrt(s_norm2) + 1.0
-m, interior, lambda, hard_case, reached_solution =
-    Optim.solve_tr_subproblem!(gr, H, delta, s)
-@assert interior
-@assert !hard_case
-@assert reached_solution
-@assert abs(m - true_m) < 1e-12
-@assert norm(s - true_s) < 1e-12
-@assert abs(lambda) < 1e-12
-
-# A boundary solution
-delta = 0.5 * sqrt(s_norm2)
-m, interior, lambda, hard_case, reached_solution =
-    Optim.solve_tr_subproblem!(gr, H, delta, s)
-@assert !interior
-@assert !hard_case
-@assert reached_solution
-@assert m > true_m
-@assert abs(norm(s) - delta) < 1e-12
-@assert lambda > 0
-
-# A "hard case" where the gradient is orthogonal to the lowest eigenvector
-
-# Test the checking
-hard_case, lambda_1_multiplicity =
-    Optim.check_hard_case_candidate([-1., 2., 3.], [0., 1., 1.])
-@assert hard_case
-@assert lambda_1_multiplicity == 1
-
-hard_case, lambda_1_multiplicity =
-    Optim.check_hard_case_candidate([-1., -1., 3.], [0., 0., 1.])
-@assert hard_case
-@assert lambda_1_multiplicity == 2
-
-hard_case, lambda_1_multiplicity =
-    Optim.check_hard_case_candidate([-1., -1., -1.], [0., 0., 0.])
-@assert hard_case
-@assert lambda_1_multiplicity == 3
-
-hard_case, lambda_1_multiplicity =
-    Optim.check_hard_case_candidate([1., 2., 3.], [0., 1., 1.])
-@assert !hard_case
-
-hard_case, lambda_1_multiplicity =
-    Optim.check_hard_case_candidate([-1., -1., -1.], [0., 0., 1.])
-@assert !hard_case
-
-hard_case, lambda_1_multiplicity =
-    Optim.check_hard_case_candidate([-1., 2., 3.], [1., 1., 1.])
-@assert !hard_case
+    delta = 0.5 * sqrt(s_norm2)
+    m, interior, lambda, hard_case, reached_solution =
+        Optim.solve_tr_subproblem!(gr, H, delta, s)
+    @assert !interior
+    @assert hard_case
+    @assert reached_solution
+    @assert abs(lambda + L[1]) < 1e-4
+    @assert abs(norm(s) - delta) < 1e-12
 
 
-# Now check an actual had case problem
-L = zeros(Float64, n) + 0.1
-L[1] = -1.
-H = U * diagm(L) * U'
-H = 0.5 * (H' + H)
-@assert issymmetric(H)
-gr = U[:,2][:]
-@assert abs(dot(gr, U[:,1][:])) < 1e-12
-true_s = -H \ gr
-s_norm2 = dot(true_s, true_s)
-true_m = dot(true_s, gr) + 0.5 * dot(true_s, H * true_s)
+    #######################################
+    # Next, test on actual optimization problems.
 
-delta = 0.5 * sqrt(s_norm2)
-m, interior, lambda, hard_case, reached_solution =
-    Optim.solve_tr_subproblem!(gr, H, delta, s)
-@assert !interior
-@assert hard_case
-@assert reached_solution
-@assert abs(lambda + L[1]) < 1e-4
-@assert abs(norm(s) - delta) < 1e-12
+    function f(x::Vector)
+        (x[1] - 5.0)^4
+    end
 
+    function g!(x::Vector, storage::Vector)
+        storage[1] = 4.0 * (x[1] - 5.0)^3
+    end
 
-#######################################
-# Next, test on actual optimization problems.
+    function h!(x::Vector, storage::Matrix)
+        storage[1, 1] = 12.0 * (x[1] - 5.0)^2
+    end
 
-function f(x::Vector)
-    (x[1] - 5.0)^4
-end
+    d = TwiceDifferentiableFunction(f, g!, h!)
 
-function g!(x::Vector, storage::Vector)
-    storage[1] = 4.0 * (x[1] - 5.0)^3
-end
+    results = Optim.optimize(d, [0.0], method=NewtonTrustRegion())
+    @assert length(results.trace.states) == 0
+    @assert results.g_converged
+    @assert norm(results.minimum - [5.0]) < 0.01
 
-function h!(x::Vector, storage::Matrix)
-    storage[1, 1] = 12.0 * (x[1] - 5.0)^2
-end
+    eta = 0.9
 
-d = TwiceDifferentiableFunction(f, g!, h!)
+    function f_2(x::Vector)
+        0.5 * (x[1]^2 + eta * x[2]^2)
+    end
 
-results = Optim.optimize(d, [0.0], method=NewtonTrustRegion())
-@assert length(results.trace.states) == 0
-@assert results.g_converged
-@assert norm(results.minimum - [5.0]) < 0.01
+    function g!_2(x::Vector, storage::Vector)
+        storage[1] = x[1]
+        storage[2] = eta * x[2]
+    end
 
-eta = 0.9
+    function h!_2(x::Vector, storage::Matrix)
+        storage[1, 1] = 1.0
+        storage[1, 2] = 0.0
+        storage[2, 1] = 0.0
+        storage[2, 2] = eta
+    end
 
-function f_2(x::Vector)
-    0.5 * (x[1]^2 + eta * x[2]^2)
-end
+    d = TwiceDifferentiableFunction(f_2, g!_2, h!_2)
 
-function g!_2(x::Vector, storage::Vector)
-    storage[1] = x[1]
-    storage[2] = eta * x[2]
-end
+    results = Optim.optimize(d, Float64[127, 921], method=NewtonTrustRegion())
+    @assert results.g_converged
+    @assert norm(results.minimum - [0.0, 0.0]) < 0.01
 
-function h!_2(x::Vector, storage::Matrix)
-    storage[1, 1] = 1.0
-    storage[1, 2] = 0.0
-    storage[2, 1] = 0.0
-    storage[2, 2] = eta
-end
-
-d = TwiceDifferentiableFunction(f_2, g!_2, h!_2)
-
-results = Optim.optimize(d, Float64[127, 921], method=NewtonTrustRegion())
-@assert results.g_converged
-@assert norm(results.minimum - [0.0, 0.0]) < 0.01
-
-# Test Optim.newton for all twice differentiable functions in
-# Optim.UnconstrainedProblems.examples
-for (name, prob) in Optim.UnconstrainedProblems.examples
-    if prob.istwicedifferentiable
-        ddf = TwiceDifferentiableFunction(prob.f, prob.g!,prob.h!)
-        res = Optim.optimize(ddf, prob.initial_x, method=NewtonTrustRegion())
-        @assert norm(res.minimum - prob.solutions) < 1e-2
-        @assert res.f_converged || res.x_converged || res.g_converged
+    # Test Optim.newton for all twice differentiable functions in
+    # Optim.UnconstrainedProblems.examples
+    for (name, prob) in Optim.UnconstrainedProblems.examples
+        if prob.istwicedifferentiable
+            ddf = TwiceDifferentiableFunction(prob.f, prob.g!,prob.h!)
+            res = Optim.optimize(ddf, prob.initial_x, method=NewtonTrustRegion())
+            @assert norm(res.minimum - prob.solutions) < 1e-2
+            @assert res.f_converged || res.x_converged || res.g_converged
+        end
     end
 end

--- a/test/optimize.jl
+++ b/test/optimize.jl
@@ -1,42 +1,44 @@
-eta = 0.9
+let
+    eta = 0.9
 
-function f1(x)
-    (1.0 / 2.0) * (x[1]^2 + eta * x[2]^2)
+    function f1(x)
+        (1.0 / 2.0) * (x[1]^2 + eta * x[2]^2)
+    end
+
+    function g1(x, storage)
+        storage[1] = x[1]
+        storage[2] = eta * x[2]
+    end
+
+    function h1(x, storage)
+        storage[1, 1] = 1.0
+        storage[1, 2] = 0.0
+        storage[2, 1] = 0.0
+        storage[2, 2] = eta
+    end
+
+    results = optimize(f1, g1, h1, [127.0, 921.0])
+    @assert Optim.g_converged(results)
+    @assert norm(Optim.minimizer(results) - [0.0, 0.0]) < 0.01
+
+    results = optimize(f1, g1, [127.0, 921.0])
+    @assert Optim.g_converged(results)
+    @assert norm(Optim.minimizer(results) - [0.0, 0.0]) < 0.01
+
+    results = optimize(f1, [127.0, 921.0])
+    @assert Optim.g_converged(results)
+    @assert norm(Optim.minimizer(results) - [0.0, 0.0]) < 0.01
+
+    results = optimize(f1, [127.0, 921.0], autodiff = true)
+    @assert Optim.g_converged(results)
+    @assert norm(Optim.minimizer(results) - [0.0, 0.0]) < 0.01
+
+    # tests for bfgs_initial_invH
+    initial_invH = zeros(2,2)
+    h1([127.0, 921.0],initial_invH)
+    initial_invH = diagm(diag(initial_invH))
+    results = optimize(DifferentiableFunction(f1, g1), [127.0, 921.0], BFGS(), OptimizationOptions(),
+                       initial_invH = initial_invH)
+    @assert Optim.g_converged(results)
+    @assert norm(Optim.minimizer(results) - [0.0, 0.0]) < 0.01
 end
-
-function g1(x, storage)
-    storage[1] = x[1]
-    storage[2] = eta * x[2]
-end
-
-function h1(x, storage)
-    storage[1, 1] = 1.0
-    storage[1, 2] = 0.0
-    storage[2, 1] = 0.0
-    storage[2, 2] = eta
-end
-
-results = optimize(f1, g1, h1, [127.0, 921.0])
-@assert Optim.g_converged(results)
-@assert norm(Optim.minimizer(results) - [0.0, 0.0]) < 0.01
-
-results = optimize(f1, g1, [127.0, 921.0])
-@assert Optim.g_converged(results)
-@assert norm(Optim.minimizer(results) - [0.0, 0.0]) < 0.01
-
-results = optimize(f1, [127.0, 921.0])
-@assert Optim.g_converged(results)
-@assert norm(Optim.minimizer(results) - [0.0, 0.0]) < 0.01
-
-results = optimize(f1, [127.0, 921.0], autodiff = true)
-@assert Optim.g_converged(results)
-@assert norm(Optim.minimizer(results) - [0.0, 0.0]) < 0.01
-
-# tests for bfgs_initial_invH
-initial_invH = zeros(2,2)
-h1([127.0, 921.0],initial_invH)
-initial_invH = diagm(diag(initial_invH))
-results = optimize(DifferentiableFunction(f1, g1), [127.0, 921.0], BFGS(), OptimizationOptions(),
-                   initial_invH = initial_invH)
-@assert Optim.g_converged(results)
-@assert norm(Optim.minimizer(results) - [0.0, 0.0]) < 0.01

--- a/test/particle_swarm.jl
+++ b/test/particle_swarm.jl
@@ -1,27 +1,31 @@
-srand(100)
+let
+    srand(100)
 
-function f_s(x::Vector)
-    (x[1] - 5.0)^4
+    function f_s(x::Vector)
+        (x[1] - 5.0)^4
+    end
+
+    function rosenbrock_s(x::Vector)
+        (1.0 - x[1])^2 + 100.0 * (x[2] - x[1]^2)^2
+    end
+
+    initial_x = [0.0]
+    upper = [100.0]
+    lower = [-100.0]
+    n_particles = 4
+
+    res = Optim.optimize(f_s, initial_x, method=ParticleSwarm(lower, upper, n_particles),
+                         iterations=100)
+    @assert norm(Optim.minimizer(res) - [5.0]) < 0.1
+
+    initial_x = [0.0, 0.0]
+    lower = [-20., -20.]
+    upper = [20., 20.]
+    n_particles = 5
+    res = Optim.optimize(rosenbrock_s, initial_x, method=ParticleSwarm(lower, upper, n_particles),
+                             iterations=300)
+    @assert norm(Optim.minimizer(res) - [1.0, 1.0]) < 0.1
+
+    # Add UnconstrainedProblems here; currently they take too many iterations to be
+    # feasible
 end
-
-function rosenbrock_s(x::Vector)
-    (1.0 - x[1])^2 + 100.0 * (x[2] - x[1]^2)^2
-end
-
-
-initial_x = [0.0]
-upper = [100.0]
-lower = [-100.0]
-n_particles = 4
-
-res = Optim.optimize(f_s, initial_x, method=ParticleSwarm(lower, upper, n_particles),
-                     iterations=100)
-@assert norm(Optim.minimizer(res) - [5.0]) < 0.1
-
-initial_x = [0.0, 0.0]
-lower = [-20., -20.]
-upper = [20., 20.]
-n_particles = 5
-res = Optim.optimize(rosenbrock_s, initial_x, method=ParticleSwarm(lower, upper, n_particles),
-                         iterations=300)
-@assert norm(Optim.minimizer(res) - [1.0, 1.0]) < 0.1

--- a/test/precon.jl
+++ b/test/precon.jl
@@ -7,36 +7,37 @@
 #     equivalent (in the limit h → 0) to that induced by the hessian, but
 #     does not approximate the hessian explicitly.
 
-using Optim
-plap(U; n=length(U)) = (n-1) * sum( (0.1 + diff(U).^2).^2 ) - sum(U) / (n-1)
-plap1(U; n=length(U), dU = diff(U), dW = 4 * (0.1 + dU.^2) .* dU) =
-                        (n-1) * ([0.0; dW] - [dW; 0.0]) - ones(U) / (n-1)
-precond(x::Vector) = precond(length(x))
-precond(n::Number) = spdiagm( ( -ones(n-1), 2*ones(n), -ones(n-1) ),
-                              (-1,0,1), n, n) * (n+1)
-df = DifferentiableFunction( X->plap([0;X;0]),
-                             (X, G)->copy!(G, (plap1([0;X;0]))[2:end-1]) )
+let
+    plap(U; n=length(U)) = (n-1) * sum( (0.1 + diff(U).^2).^2 ) - sum(U) / (n-1)
+    plap1(U; n=length(U), dU = diff(U), dW = 4 * (0.1 + dU.^2) .* dU) =
+                            (n-1) * ([0.0; dW] - [dW; 0.0]) - ones(U) / (n-1)
+    precond(x::Vector) = precond(length(x))
+    precond(n::Number) = spdiagm( ( -ones(n-1), 2*ones(n), -ones(n-1) ),
+                                  (-1,0,1), n, n) * (n+1)
+    df = DifferentiableFunction( X->plap([0;X;0]),
+                                 (X, G)->copy!(G, (plap1([0;X;0]))[2:end-1]) )
 
-GRTOL = 1e-6
+    GRTOL = 1e-6
 
-println("Test a basic preconditioning example")
-for N in (10, 50, 250)
-    println("N = ", N)
-    initial_x = zeros(N)
-    Plap = precond(initial_x)
-    ID = nothing
-    for Optimiser in (GradientDescent, ConjugateGradient, LBFGS)
-        for (P, wwo) in zip((ID, Plap), (" WITHOUT", " WITH"))
-            results = Optim.optimize(df, copy(initial_x),
-                                     method=Optimiser(P = P),
-                                     f_tol = 1e-32, g_tol = GRTOL )
-            println(Optimiser, wwo,
-                    " preconditioning : g_calls = ", results.g_calls,
-                    ", f_calls = ", results.f_calls)
-            if (Optimiser == GradientDescent) && (N > 15) && (P == ID)
-                println("    (gradient descent is not expected to converge)")
-            else
-                @assert Optim.converged(results)
+    println("Test a basic preconditioning example")
+    for N in (10, 50, 250)
+        println("N = ", N)
+        initial_x = zeros(N)
+        Plap = precond(initial_x)
+        ID = nothing
+        for Optimiser in (GradientDescent, ConjugateGradient, LBFGS)
+            for (P, wwo) in zip((ID, Plap), (" WITHOUT", " WITH"))
+                results = Optim.optimize(df, copy(initial_x),
+                                         method=Optimiser(P = P),
+                                         f_tol = 1e-32, g_tol = GRTOL )
+                println(Optimiser, wwo,
+                        " preconditioning : g_calls = ", results.g_calls,
+                        ", f_calls = ", results.f_calls)
+                if (Optimiser == GradientDescent) && (N > 15) && (P == ID)
+                    println("    (gradient descent is not expected to converge)")
+                else
+                    @assert Optim.converged(results)
+                end
             end
         end
     end

--- a/test/simulated_annealing.jl
+++ b/test/simulated_annealing.jl
@@ -1,15 +1,17 @@
-srand(1)
+let
+    srand(1)
 
-function f_s(x::Vector)
-    (x[1] - 5.0)^4
+    function f_s(x::Vector)
+        (x[1] - 5.0)^4
+    end
+
+    results = Optim.optimize(f_s, [0.0], method=SimulatedAnnealing(), iterations=100_000)
+    @assert norm(Optim.minimizer(results) - [5.0]) < 0.1
+
+    function rosenbrock_s(x::Vector)
+        (1.0 - x[1])^2 + 100.0 * (x[2] - x[1]^2)^2
+    end
+
+    results = Optim.optimize(rosenbrock_s, [0.0, 0.0], method=SimulatedAnnealing(), iterations=100_000)
+    @assert norm(Optim.minimizer(results) - [1.0, 1.0]) < 0.1
 end
-
-results = Optim.optimize(f_s, [0.0], method=SimulatedAnnealing(), iterations=100_000)
-@assert norm(Optim.minimizer(results) - [5.0]) < 0.1
-
-function rosenbrock_s(x::Vector)
-    (1.0 - x[1])^2 + 100.0 * (x[2] - x[1]^2)^2
-end
-
-results = Optim.optimize(rosenbrock_s, [0.0, 0.0], method=SimulatedAnnealing(), iterations=100_000)
-@assert norm(Optim.minimizer(results) - [1.0, 1.0]) < 0.1

--- a/test/type_stability.jl
+++ b/test/type_stability.jl
@@ -1,49 +1,51 @@
-function rosenbrock{T}(x::Vector{T})
-    o = one(T)
-    c = convert(T,100)
-    return (o - x[1])^2 + c * (x[2] - x[1]^2)^2
-end
+let
+    function rosenbrock{T}(x::Vector{T})
+        o = one(T)
+        c = convert(T,100)
+        return (o - x[1])^2 + c * (x[2] - x[1]^2)^2
+    end
 
-function rosenbrock_gradient!{T}(x::Vector{T}, storage::Vector{T})
-    o = one(T)
-    c = convert(T,100)
-    storage[1] = (-2*o) * (o - x[1]) - (4*c) * (x[2] - x[1]^2) * x[1]
-    storage[2] = (2*c) * (x[2] - x[1]^2)
-end
+    function rosenbrock_gradient!{T}(x::Vector{T}, storage::Vector{T})
+        o = one(T)
+        c = convert(T,100)
+        storage[1] = (-2*o) * (o - x[1]) - (4*c) * (x[2] - x[1]^2) * x[1]
+        storage[2] = (2*c) * (x[2] - x[1]^2)
+    end
 
-function rosenbrock_hessian!{T}(x::Vector{T}, storage::Matrix{T})
-    o = one(T)
-    c = convert(T,100)
-    f = 4*c
-    storage[1, 1] = (2*o) - f * x[2] + 3 * f * x[1]^2
-    storage[1, 2] = -f * x[1]
-    storage[2, 1] = -f * x[1]
-    storage[2, 2] = 2*c
-end
+    function rosenbrock_hessian!{T}(x::Vector{T}, storage::Matrix{T})
+        o = one(T)
+        c = convert(T,100)
+        f = 4*c
+        storage[1, 1] = (2*o) - f * x[2] + 3 * f * x[1]^2
+        storage[1, 2] = -f * x[1]
+        storage[2, 1] = -f * x[1]
+        storage[2, 2] = 2*c
+    end
 
-d2 = DifferentiableFunction(rosenbrock,
-                            rosenbrock_gradient!)
-d3 = TwiceDifferentiableFunction(rosenbrock,
-                                 rosenbrock_gradient!,
-                                 rosenbrock_hessian!)
+    d2 = DifferentiableFunction(rosenbrock,
+                                rosenbrock_gradient!)
+    d3 = TwiceDifferentiableFunction(rosenbrock,
+                                     rosenbrock_gradient!,
+                                     rosenbrock_hessian!)
 
-for method in (NelderMead(),
-               SimulatedAnnealing())
-    optimize(rosenbrock, [0.0,0,.0], method = method)
-    optimize(rosenbrock, Float32[0.0, 0.0], method = method)
-end
+    for method in (NelderMead(),
+                   SimulatedAnnealing())
+        optimize(rosenbrock, [0.0,0,.0], method = method)
+        optimize(rosenbrock, Float32[0.0, 0.0], method = method)
+    end
 
-for method in (BFGS(),
-               ConjugateGradient(),
-               GradientDescent(),
-               MomentumGradientDescent(),
-#                :accelerated_gradient_descent,
-               LBFGS())
-    optimize(d2, [0.0,0,.0], method = method)
-    optimize(d2, Float32[0.0, 0.0], method = method)
-end
+    for method in (BFGS(),
+                   ConjugateGradient(),
+                   GradientDescent(),
+                   MomentumGradientDescent(),
+    #                :accelerated_gradient_descent,
+                   LBFGS())
+        optimize(d2, [0.0,0,.0], method = method)
+        optimize(d2, Float32[0.0, 0.0], method = method)
+    end
 
-for method in (Newton(),)
-    optimize(d3, [0.0,0.0], method = method)
-    optimize(d3, Float32[0.0, 0.0], method = method)
+    for method in (Newton(),)
+        optimize(d3, [0.0,0.0], method = method)
+        optimize(d3, Float32[0.0, 0.0], method = method)
+    end
 end

--- a/test/types.jl
+++ b/test/types.jl
@@ -1,8 +1,4 @@
-module TestTypes
-    using Base.Test
-    using Compat
-    using Optim
-
+let
     solver = NelderMead()
     T = typeof(solver)
     trace = OptimizationTrace(solver)


### PR DESCRIPTION
…or some multivariate solvers.

To my surprise, stuff like BFGS wasn't even tested on the UnconstrainedProblems!

Momentum Gradient Descent has some cases filtered out, as it will increase the objective value at some point, even if it will converge eventually. This is expected, but currently we use `!converged` in the while logic. I wonder if we should simply replace `f_converged` with something like
```julia
f_converged = abs(f_x - f_x_previous) / (abs(f_x) + o.f_tol) < o.f_tol || (nextfloat(f_x) >= f_x_previous && f_x < f_x_previous)
```
just below the convergence assessment in accelerated and momentum gradient descent. Right now it "converges" on an increase, which is unfortunate... Different issue though!

*Edit* For future reference: all the `let`'s are simply to be sure that all tests are "isolated". We might want to use the next testset-thing, but I have only seen it by name, so that is in a future commit. This fixed method overwritten warnings on master/RC. 