### PR TITLE
Simplify OptimizationTrace as a Vector{T<:OptimizationState}

### DIFF
--- a/src/accelerated_gradient_descent.jl
+++ b/src/accelerated_gradient_descent.jl
@@ -80,7 +80,7 @@ function optimize{T}(d::DifferentiableFunction,
     lsr = LineSearchResults(T)
 
     # Trace the history of states visited
-    tr = OptimizationTrace(mo)
+    tr = OptimizationTrace{typeof(mo)}()
     tracing = o.store_trace || o.show_trace || o.extended_trace || o.callback != nothing
     @agdtrace
 

--- a/src/api.jl
+++ b/src/api.jl
@@ -3,35 +3,35 @@ minimizer(r::OptimizationResults) = r.minimum
 minimum(r::OptimizationResults) = r.f_minimum
 iterations(r::OptimizationResults) = r.iterations
 iteration_limit_reached(r::OptimizationResults) = r.iteration_converged
-trace(r::OptimizationResults) = length(r.trace.states) > 0 ? r.trace : error("No trace in optimization results. To get a trace, run optimize() with store_trace = true.")
+trace(r::OptimizationResults) = length(r.trace) > 0 ? r.trace : error("No trace in optimization results. To get a trace, run optimize() with store_trace = true.")
 
 function x_trace(r::UnivariateOptimizationResults)
 	tr = trace(r)
-	!haskey(tr.states[1].metadata, "x_minimum") && error("Trace does not contain x. To get a trace of x, run optimize() with extended_trace = true")
-    [state.metadata["x_minimum"] for state in tr.states]
+	!haskey(tr[1].metadata, "x_minimum") && error("Trace does not contain x. To get a trace of x, run optimize() with extended_trace = true")
+    [ state.metadata["x_minimum"] for state in tr ]
 end
 function x_lower_trace(r::UnivariateOptimizationResults)
 	tr = trace(r)
-	!haskey(tr.states[1].metadata, "x_lower") && error("Trace does not contain x. To get a trace of x, run optimize() with extended_trace = true")
-    [state.metadata["x_lower"] for state in tr.states]
+	!haskey(tr[1].metadata, "x_lower") && error("Trace does not contain x. To get a trace of x, run optimize() with extended_trace = true")
+    [ state.metadata["x_lower"] for state in tr ]
 end
 x_lower_trace(r::MultivariateOptimizationResults) = error("x_lower_trace is not implemented for $(method(r)).")
 function x_upper_trace(r::UnivariateOptimizationResults)
 	tr = trace(r)
-	!haskey(tr.states[1].metadata, "x_upper") && error("Trace does not contain x. To get a trace of x, run optimize() with extended_trace = true")
-    [state.metadata["x_upper"] for state in tr.states]
+	!haskey(tr[1].metadata, "x_upper") && error("Trace does not contain x. To get a trace of x, run optimize() with extended_trace = true")
+    [ state.metadata["x_upper"] for state in tr ]
 end
 x_upper_trace(r::MultivariateOptimizationResults) = error("x_upper_trace is not implemented for $(method(r)).")
 
 function x_trace(r::MultivariateOptimizationResults)
 	tr = trace(r)
-	!haskey(tr.states[1].metadata, "x") && error("Trace does not contain x. To get a trace of x, run optimize() with extended_trace = true")
-    [state.metadata["x"] for state in tr.states]
+	!haskey(tr[1].metadata, "x") && error("Trace does not contain x. To get a trace of x, run optimize() with extended_trace = true")
+    [ state.metadata["x"] for state in tr ]
 end
 
-f_trace(r::OptimizationResults) = [state.value for state in trace(r).states]
+f_trace(r::OptimizationResults) = [ state.value for state in trace(r) ]
 g_norm_trace(r::OptimizationResults) = error("g_norm_trace is not implemented for $(method(r)).")
-g_norm_trace(r::MultivariateOptimizationResults) = [state.g_norm for state in trace(r).states]
+g_norm_trace(r::MultivariateOptimizationResults) = [ state.g_norm for state in trace(r) ]
 
 f_calls(r::OptimizationResults) = r.f_calls
 

--- a/src/bfgs.jl
+++ b/src/bfgs.jl
@@ -88,7 +88,7 @@ function optimize{T}(d::DifferentiableFunction,
     I = eye(size(invH)...)
 
     # Trace the history of states visited
-    tr = OptimizationTrace(mo)
+    tr = OptimizationTrace{typeof(mo)}()
     tracing = o.store_trace || o.show_trace || o.extended_trace || o.callback != nothing
     @bfgstrace
 

--- a/src/brent.jl
+++ b/src/brent.jl
@@ -61,7 +61,7 @@ function optimize{T <: AbstractFloat}(
     converged = false
 
     # Trace the history of states visited
-    tr = OptimizationTrace(mo)
+    tr = OptimizationTrace{typeof(mo)}()
     tracing = store_trace || show_trace || extended_trace || callback != nothing
     @brenttrace
 

--- a/src/cg.jl
+++ b/src/cg.jl
@@ -145,7 +145,7 @@ function optimize{T}(df::DifferentiableFunction,
     lsr = LineSearchResults(T)
 
     # Trace the history of states visited
-    tr = OptimizationTrace(mo)
+    tr = OptimizationTrace{typeof(mo)}()
     tracing = o.store_trace || o.show_trace || o.extended_trace || o.callback != nothing
     @cgtrace
 

--- a/src/golden_section.jl
+++ b/src/golden_section.jl
@@ -51,7 +51,7 @@ function optimize{T <: AbstractFloat}(f::Function, x_lower::T, x_upper::T,
     converged = false
 
     # Trace the history of states visited
-    tr = OptimizationTrace(mo)
+    tr = OptimizationTrace{typeof(mo)}()
     tracing = store_trace || show_trace || extended_trace || callback != nothing
     @goldensectiontrace
 

--- a/src/gradient_descent.jl
+++ b/src/gradient_descent.jl
@@ -75,7 +75,7 @@ function optimize{T}(d::DifferentiableFunction,
     lsr = LineSearchResults(T)
 
     # Trace the history of states visited
-    tr = OptimizationTrace(mo)
+    tr = OptimizationTrace{typeof(mo)}()
     tracing = o.store_trace || o.show_trace || o.extended_trace || o.callback != nothing
     @gdtrace
 

--- a/src/l_bfgs.jl
+++ b/src/l_bfgs.jl
@@ -148,7 +148,7 @@ function optimize{T}(d::DifferentiableFunction,
     twoloop_q, twoloop_alpha = Array(T, n), Array(T, mo.m)
 
     # Trace the history of states visited
-    tr = OptimizationTrace(mo)
+    tr = OptimizationTrace{typeof(mo)}()
     tracing = o.store_trace || o.show_trace || o.extended_trace || o.callback != nothing
     @lbfgstrace
 

--- a/src/levenberg_marquardt.jl
+++ b/src/levenberg_marquardt.jl
@@ -60,7 +60,7 @@ function levenberg_marquardt{T}(f::Function, g::Function, initial_x::AbstractVec
     m_buffer = Vector{T}(m)
 
     # Maintain a trace of the system.
-    tr = OptimizationTrace(LevenbergMarquardt())
+    tr = OptimizationTrace{typeof(LevenbergMarquardt())}()
     if show_trace
         d = Dict("lambda" => lambda)
         os = OptimizationState(iterCt, sumabs2(fcur), NaN, d)

--- a/src/momentum_gradient_descent.jl
+++ b/src/momentum_gradient_descent.jl
@@ -73,7 +73,7 @@ function optimize{T}(d::DifferentiableFunction,
     lsr = LineSearchResults(T)
 
     # Trace the history of states visited
-    tr = OptimizationTrace(mo)
+    tr = OptimizationTrace{typeof(mo)}()
     tracing = o.store_trace || o.show_trace || o.extended_trace || o.callback != nothing
     @mgdtrace
 

--- a/src/nelder_mead.jl
+++ b/src/nelder_mead.jl
@@ -151,7 +151,7 @@ function optimize{T}(f::Function,
     # Maintain a trace
     f_x_previous, f_x = NaN, nmobjective(f_simplex, m, n)
     f_lowest = f_simplex[i_order[1]]
-    tr = OptimizationTrace(mo)
+    tr = OptimizationTrace{typeof(mo)}()
     tracing = o.show_trace || o.store_trace || o.extended_trace || o.callback != nothing
     @nmtrace
 

--- a/src/newton.jl
+++ b/src/newton.jl
@@ -82,7 +82,7 @@ function optimize{T}(d::TwiceDifferentiableFunction,
     lsr = LineSearchResults(T)
 
     # Trace the history of states visited
-    tr = OptimizationTrace(mo)
+    tr = OptimizationTrace{typeof(mo)}()
     tracing = o.store_trace || o.show_trace || o.extended_trace || o.callback != nothing
     @newtontrace
 

--- a/src/newton_trust_region.jl
+++ b/src/newton_trust_region.jl
@@ -284,7 +284,7 @@ function optimize{T}(d::TwiceDifferentiableFunction,
     lambda = NaN
 
     # Trace the history of states visited
-    tr = OptimizationTrace(mo)
+    tr = OptimizationTrace{typeof(mo)}()
     tracing = o.store_trace || o.show_trace || o.extended_trace || o.callback != nothing
     @newton_tr_trace
 

--- a/src/particle_swarm.jl
+++ b/src/particle_swarm.jl
@@ -123,7 +123,7 @@ function optimize{T}(cost_function::Function,
         X[j, 1] = initial_x[j]
         X_best[j, 1] = initial_x[j]
     end
-    tr = OptimizationTrace(mo)
+    tr = OptimizationTrace{typeof(mo)}()
 
     tracing = o.store_trace || o.show_trace || o.extended_trace || o.callback != nothing
     @swarmtrace

--- a/src/simulated_annealing.jl
+++ b/src/simulated_annealing.jl
@@ -70,7 +70,7 @@ function optimize{T}(cost::Function,
     best_f_x = f_x
 
     # Trace the history of states visited
-    tr = OptimizationTrace(mo)
+    tr = OptimizationTrace{typeof(mo)}()
     tracing = o.store_trace || o.show_trace || o.extended_trace || o.callback != nothing
     @satrace
 

--- a/test/callbacks.jl
+++ b/test/callbacks.jl
@@ -12,7 +12,7 @@ let
                    SimulatedAnnealing())
         ot_run = false
         cb = tr -> begin
-            @test tr.states[end].iteration % 3 == 0
+            @test tr[end].iteration % 3 == 0
             ot_run = true
         end
         optimize(f, initial_x, method = method, callback = cb, show_every=3, store_trace=true)
@@ -33,7 +33,7 @@ let
                    MomentumGradientDescent())
         ot_run = false
         cb = tr -> begin
-            @test tr.states[end].iteration % 3 == 0
+            @test tr[end].iteration % 3 == 0
             ot_run = true
         end
         optimize(d2, initial_x, method = method, callback = cb, show_every=3, store_trace=true)
@@ -51,7 +51,7 @@ let
     for method in (Newton(),)
         ot_run = false
         cb = tr -> begin
-            @test tr.states[end].iteration % 3 == 0
+            @test tr[end].iteration % 3 == 0
             ot_run = true
         end
         optimize(d3, initial_x, method = method, callback = cb, show_every=3, store_trace=true)

--- a/test/newton_trust_region.jl
+++ b/test/newton_trust_region.jl
@@ -109,7 +109,7 @@ let
     d = TwiceDifferentiableFunction(f, g!, h!)
 
     results = Optim.optimize(d, [0.0], method=NewtonTrustRegion())
-    @assert length(results.trace.states) == 0
+    @assert length(results.trace) == 0
     @assert results.g_converged
     @assert norm(results.minimum - [5.0]) < 0.01
 

--- a/test/types.jl
+++ b/test/types.jl
@@ -1,7 +1,7 @@
 let
     solver = NelderMead()
     T = typeof(solver)
-    trace = OptimizationTrace(solver)
+    trace = OptimizationTrace{T}()
     push!(trace,OptimizationState{T}(1,1.0,1.0,Dict()))
     push!(trace,OptimizationState{T}(2,1.0,1.0,Dict()))
     @test length(trace) == 2


### PR DESCRIPTION
Here is a sketch of how I would implement `OptimizationTrace`. I didn't add any new tests, but it looks like the appropriate checks are already in place.

The only thing that is slightly funky is that `optimize` end up initializing the `OptimizationTrace` like this:

```julia
mo = NelderMead()
OptimizationTrace{typeof(mo)}()
```

There might be something more elegant, but this seems okay to me at least. Let me know your thoughts.