### PR TITLE
fixed levenberg_marquardt/show_trace crash

### DIFF
--- a/src/levenberg_marquardt.jl
+++ b/src/levenberg_marquardt.jl
@@ -60,10 +60,10 @@ function levenberg_marquardt{T}(f::Function, g::Function, initial_x::AbstractVec
     m_buffer = Vector{T}(m)
 
     # Maintain a trace of the system.
-    tr = OptimizationTrace{typeof(LevenbergMarquardt())}()
+    tr = OptimizationTrace{LevenbergMarquardt}()
     if show_trace
         d = Dict("lambda" => lambda)
-        os = OptimizationState(iterCt, sumabs2(fcur), NaN, d)
+        os = OptimizationState{LevenbergMarquardt}(iterCt, sumabs2(fcur), NaN, d)
         push!(tr, os)
         println(os)
     end
@@ -154,7 +154,7 @@ function levenberg_marquardt{T}(f::Function, g::Function, initial_x::AbstractVec
             At_mul_B!(n_buffer, J, fcur)
             g_norm = norm(n_buffer, Inf)
             d = @compat Dict("g(x)" => g_norm, "dx" => delta_x, "lambda" => lambda)
-            os = OptimizationState(iterCt, sumabs2(fcur), g_norm, d)
+            os = OptimizationState{LevenbergMarquardt}(iterCt, sumabs2(fcur), g_norm, d)
             push!(tr, os)
             println(os)
         end

--- a/test/levenberg_marquardt.jl
+++ b/test/levenberg_marquardt.jl
@@ -54,7 +54,6 @@ let
         @assert norm(Optim.minimizer(results) - [1.0, 2.0]) < 0.05
     end
 
-    # tests for box constraints, PR #196
     let
         srand(12345)
 
@@ -66,6 +65,7 @@ let
         f_lsq = p -> model(xdata,p)-ydata
         g_lsq = Calculus.jacobian(f_lsq)
 
+        # tests for box constraints, PR #196
         @test_throws ArgumentError Optim.levenberg_marquardt(f_lsq, g_lsq, [15.0, 15.0, 15.0], lower=[5.0, 11.0])
         @test_throws ArgumentError Optim.levenberg_marquardt(f_lsq, g_lsq, [5.0, 5.0, 5.0], upper=[15.0, 9.0])
         @test_throws ArgumentError Optim.levenberg_marquardt(f_lsq, g_lsq, [15.0, 10.0, 15.0], lower=[5.0, 11.0, 5.0])
@@ -82,5 +82,8 @@ let
         Optim.minimizer(results)
         @test Optim.converged(results)
         @test all(Optim.minimizer(results) .<= upper)
+
+        # tests for PR #267
+        Optim.levenberg_marquardt(f_lsq, g_lsq, [15.0, 15.0, 15.0], show_trace=true)
     end
 end


### PR DESCRIPTION
this fixes a bug which crept in recently when using `show_trace=true` in levenberg_marquardt.