### PR TITLE
RFC: catch linesearch errors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,11 @@
+# Optim v0.7.2 release notes
+* Failures in a line search now terminates the optimization with a warning and status of non-convergence. The results can still be accessed, but `minimizer(res)` will not represent a local minimum.
+  See [275](https://github.com/JuliaOpt/Optim.jl/pull/275).
+
 # Optim v0.7.0 release notes
 * Refactor code internally to clean up code and allow more flexible use Optim
 * Switch to new (v.0.3) ForwardDiff
 * Make minimizer/minimum transition final
-* Failures in a line search now terminates the optimization with a warning and status of non-convergence. The results can still be accessed, but `minimizer(res)` will not represent a local minimum.
-See [277](https://github.com/JuliaOpt/Optim.jl/pull/275).
 * Fix dispatch bug for univariate optimization.
 * The line search functionality has been separated into a new package
   [LineSearches.jl](https://github.com/anriseth/LineSearches.jl), see

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 * Refactor code internally to clean up code and allow more flexible use Optim
 * Switch to new (v.0.3) ForwardDiff
 * Make minimizer/minimum transition final
+* Failures in a line search now terminates the optimization with a warning and status of non-convergence. The results can still be accessed, but `minimizer(res)` will not represent a local minimum.
+See [277](https://github.com/JuliaOpt/Optim.jl/pull/275).
 * Fix dispatch bug for univariate optimization.
 * The line search functionality has been separated into a new package
   [LineSearches.jl](https://github.com/anriseth/LineSearches.jl), see

--- a/REQUIRE
+++ b/REQUIRE
@@ -3,4 +3,4 @@ Calculus
 ForwardDiff 0.3.0 0.4.0
 PositiveFactorizations
 Compat 0.8.4
-LineSearches 0.1.1
+LineSearches 0.1.2

--- a/REQUIRE
+++ b/REQUIRE
@@ -3,4 +3,4 @@ Calculus
 ForwardDiff 0.3.0 0.4.0
 PositiveFactorizations
 Compat 0.8.4
-LineSearches 0.1.0
+LineSearches 0.1.1

--- a/src/accelerated_gradient_descent.jl
+++ b/src/accelerated_gradient_descent.jl
@@ -70,8 +70,7 @@ function update_state!{T}(d, state::AcceleratedGradientDescentState{T}, method::
         if isa(ex, LineSearches.LineSearchException)
             lssuccess = false
             state.f_calls, state.g_calls = state.f_calls + ex.f_update, state.g_calls + ex.g_update
-            state.alpha = max(ex.alpha, 1e-12)
-            #state.alpha = ex.alpha
+            state.alpha = ex.alpha
             Base.warn("Linesearch failed, using alpha = $(state.alpha) and exiting optimization.")
         else
             rethrow(ex)

--- a/src/bfgs.jl
+++ b/src/bfgs.jl
@@ -82,8 +82,7 @@ function update_state!{T}(d, state::BFGSState{T}, method::BFGS)
         if isa(ex, LineSearches.LineSearchException)
             lssuccess = false
             state.f_calls, state.g_calls = state.f_calls + ex.f_update, state.g_calls + ex.g_update
-            state.alpha = max(ex.alpha, 1e-12)
-            #state.alpha = ex.alpha
+            state.alpha = ex.alpha
             Base.warn("Linesearch failed, using alpha = $(state.alpha) and exiting optimization.")
         else
             rethrow(ex)

--- a/src/cg.jl
+++ b/src/cg.jl
@@ -151,7 +151,7 @@ function update_state!{T}(df, state::ConjugateGradientState{T}, method::Conjugat
         # Determine the distance of movement along the search line
         try
             state.alpha, f_update, g_update =
-                method.linesearch!(d, state.x, state.s, state.x_ls, state.g_ls, state.lsr,
+                method.linesearch!(df, state.x, state.s, state.x_ls, state.g_ls, state.lsr,
                                    state.alpha, state.mayterminate)
             state.f_calls, state.g_calls = state.f_calls + f_update, state.g_calls + g_update
         catch ex

--- a/src/cg.jl
+++ b/src/cg.jl
@@ -158,8 +158,7 @@ function update_state!{T}(df, state::ConjugateGradientState{T}, method::Conjugat
             if isa(ex, LineSearches.LineSearchException)
                 lssuccess = false
                 state.f_calls, state.g_calls = state.f_calls + ex.f_update, state.g_calls + ex.g_update
-                state.alpha = max(ex.alpha, 1e-12)
-                #state.alpha = ex.alpha
+                state.alpha = ex.alpha
                 Base.warn("Linesearch failed, using alpha = $(state.alpha) and exiting optimization.")
             else
                 rethrow(ex)

--- a/src/gradient_descent.jl
+++ b/src/gradient_descent.jl
@@ -58,8 +58,7 @@ function update_state!{T}(d, state::GradientDescentState{T}, method::GradientDes
         if isa(ex, LineSearches.LineSearchException)
             lssuccess = false
             state.f_calls, state.g_calls = state.f_calls + ex.f_update, state.g_calls + ex.g_update
-            state.alpha = max(ex.alpha, 1e-12)
-            #state.alpha = ex.alpha
+            state.alpha = ex.alpha
             Base.warn("Linesearch failed, using alpha = $(state.alpha) and exiting optimization.")
         else
             rethrow(ex)

--- a/src/gradient_descent.jl
+++ b/src/gradient_descent.jl
@@ -36,6 +36,7 @@ function initial_state{T}(method::GradientDescent, options, d, initial_x::Array{
 end
 
 function update_state!{T}(d, state::GradientDescentState{T}, method::GradientDescent)
+    lssuccess = true
     # Search direction is always the negative preconditioned gradient
     method.precondprep!(method.P, state.x)
     A_ldiv_B!(state.s, method.P, state.g)
@@ -48,15 +49,28 @@ function update_state!{T}(d, state::GradientDescentState{T}, method::GradientDes
     push!(state.lsr, zero(T), state.f_x, dphi0)
 
     # Determine the distance of movement along the search line
-    state.alpha, f_update, g_update =
-    method.linesearch!(d, state.x, state.s, state.x_ls, state.g_ls,
-                       state.lsr, state.alpha, state.mayterminate)
-    state.f_calls, state.g_calls = state.f_calls + f_update, state.g_calls + g_update
+    try
+        state.alpha, f_update, g_update =
+            method.linesearch!(d, state.x, state.s, state.x_ls, state.g_ls,
+                               state.lsr, state.alpha, state.mayterminate)
+        state.f_calls, state.g_calls = state.f_calls + f_update, state.g_calls + g_update
+    catch ex
+        if isa(ex, LineSearches.LineSearchException)
+            lssuccess = false
+            state.f_calls, state.g_calls = state.f_calls + ex.f_update, state.g_calls + ex.g_update
+            state.alpha = max(ex.alpha, 1e-12)
+            #state.alpha = ex.alpha
+            Base.warn("Linesearch failed, using alpha = $(state.alpha) and exiting optimization.")
+        else
+            rethrow(ex)
+        end
+    end
+
 
     # Maintain a record of previous position
     copy!(state.x_previous, state.x)
 
     # Update current position # x = x + alpha * s
     LinAlg.axpy!(state.alpha, state.s, state.x)
-    false # don't force break
+    (lssuccess == false) # break on linesearch error
 end

--- a/src/l_bfgs.jl
+++ b/src/l_bfgs.jl
@@ -124,6 +124,7 @@ function initial_state{T}(method::LBFGS, options, d, initial_x::Array{T})
 end
 
 function update_state!{T}(d, state::LBFGSState{T}, method::LBFGS)
+    lssuccess = true
     n = state.n
     # Increment the number of steps we've had to perform
     state.pseudo_iteration += 1
@@ -166,10 +167,22 @@ function update_state!{T}(d, state::LBFGSState{T}, method::LBFGS)
     end
 
     # Determine the distance of movement along the search line
-    state.alpha, f_update, g_update =
-      method.linesearch!(d, state.x, state.s, state.x_ls, state.g_ls, state.lsr,
-                     alphaguess, state.mayterminate)
-    state.f_calls, state.g_calls = state.f_calls + f_update, state.g_calls + g_update
+    try
+        state.alpha, f_update, g_update =
+        method.linesearch!(d, state.x, state.s, state.x_ls, state.g_ls, state.lsr,
+                           alphaguess, state.mayterminate)
+        state.f_calls, state.g_calls = state.f_calls + f_update, state.g_calls + g_update
+    catch ex
+        if isa(ex, LineSearches.LineSearchException)
+            lssuccess = false
+            state.f_calls, state.g_calls = state.f_calls + ex.f_update, state.g_calls + ex.g_update
+            state.alpha = max(ex.alpha, 1e-12)
+            #state.alpha = ex.alpha
+            Base.warn("Linesearch failed, using alpha = $(state.alpha) and exiting optimization.")
+        else
+            rethrow(ex)
+        end
+    end
 
     # Maintain a record of previous position
     copy!(state.x_previous, state.x)
@@ -183,7 +196,7 @@ function update_state!{T}(d, state::LBFGSState{T}, method::LBFGS)
     # Save old f and g values to prepare for update_g! call
     state.f_x_previous = state.f_x
     copy!(state.g_previous, state.g)
-    false
+    (lssuccess == false) # break on linesearch error
 end
 
 

--- a/src/l_bfgs.jl
+++ b/src/l_bfgs.jl
@@ -176,8 +176,7 @@ function update_state!{T}(d, state::LBFGSState{T}, method::LBFGS)
         if isa(ex, LineSearches.LineSearchException)
             lssuccess = false
             state.f_calls, state.g_calls = state.f_calls + ex.f_update, state.g_calls + ex.g_update
-            state.alpha = max(ex.alpha, 1e-12)
-            #state.alpha = ex.alpha
+            state.alpha = ex.alpha
             Base.warn("Linesearch failed, using alpha = $(state.alpha) and exiting optimization.")
         else
             rethrow(ex)

--- a/src/momentum_gradient_descent.jl
+++ b/src/momentum_gradient_descent.jl
@@ -37,6 +37,7 @@ function initial_state{T}(method::MomentumGradientDescent, options, d, initial_x
 end
 
 function update_state!{T}(d, state::MomentumGradientDescentState{T}, method::MomentumGradientDescent)
+    lssuccess = true
     # Search direction is always the negative gradient
     @simd for i in 1:state.n
         @inbounds state.s[i] = -state.g[i]
@@ -48,9 +49,22 @@ function update_state!{T}(d, state::MomentumGradientDescentState{T}, method::Mom
     push!(state.lsr, zero(T), state.f_x, dphi0)
 
     # Determine the distance of movement along the search line
-    state.alpha, f_update, g_update =
-      method.linesearch!(d, state.x, state.s, state.x_ls, state.g_ls, state.lsr, state.alpha, state.mayterminate)
-    state.f_calls, state.g_calls = state.f_calls + f_update, state.g_calls + g_update
+    try
+        state.alpha, f_update, g_update =
+        method.linesearch!(d, state.x, state.s, state.x_ls, state.g_ls, state.lsr,
+                           state.alpha, state.mayterminate)
+        state.f_calls, state.g_calls = state.f_calls + f_update, state.g_calls + g_update
+    catch ex
+        if isa(ex, LineSearches.LineSearchException)
+            lssuccess = false
+            state.f_calls, state.g_calls = state.f_calls + ex.f_update, state.g_calls + ex.g_update
+            state.alpha = max(ex.alpha, 1e-12)
+            #state.alpha = ex.alpha
+            Base.warn("Linesearch failed, using alpha = $(state.alpha) and exiting optimization.")
+        else
+            rethrow(ex)
+        end
+    end
 
     # Update current position
     @simd for i in 1:state.n
@@ -59,5 +73,5 @@ function update_state!{T}(d, state::MomentumGradientDescentState{T}, method::Mom
         @inbounds state.x_previous[i] = state.x[i]
         @inbounds state.x[i] = state.x[i] + state.alpha * state.s[i] + method.mu * (state.x[i] - tmp)
     end
-    false # don't force break
+    (lssuccess == false) # break on linesearch error
 end

--- a/src/momentum_gradient_descent.jl
+++ b/src/momentum_gradient_descent.jl
@@ -58,8 +58,7 @@ function update_state!{T}(d, state::MomentumGradientDescentState{T}, method::Mom
         if isa(ex, LineSearches.LineSearchException)
             lssuccess = false
             state.f_calls, state.g_calls = state.f_calls + ex.f_update, state.g_calls + ex.g_update
-            state.alpha = max(ex.alpha, 1e-12)
-            #state.alpha = ex.alpha
+            state.alpha = ex.alpha
             Base.warn("Linesearch failed, using alpha = $(state.alpha) and exiting optimization.")
         else
             rethrow(ex)

--- a/src/newton.jl
+++ b/src/newton.jl
@@ -47,7 +47,7 @@ function initial_state{T}(method::Newton, options, d, initial_x::Array{T})
   end
 
   function update_state!{T}(d, state::NewtonState{T}, method::Newton)
-
+        lssuccess = true
         # Search direction is always the negative gradient divided by
         # a matrix encoding the absolute values of the curvatures
         # represented by H. It deviates from the usual "add a scaled
@@ -62,14 +62,27 @@ function initial_state{T}(method::Newton, options, d, initial_x::Array{T})
         push!(state.lsr, zero(T), state.f_x, dphi0)
 
         # Determine the distance of movement along the search line
-        state.alpha, f_update, g_update =
-          method.linesearch!(d, state.x, state.s, state.x_ls, state.g_ls, state.lsr, state.alpha, state.mayterminate)
-        state.f_calls, state.g_calls = state.f_calls + f_update, state.g_calls + g_update
+        try
+            state.alpha, f_update, g_update =
+                method.linesearch!(d, state.x, state.s, state.x_ls, state.g_ls, state.lsr,
+                                   state.alpha, state.mayterminate)
+            state.f_calls, state.g_calls = state.f_calls + f_update, state.g_calls + g_update
+        catch ex
+            if isa(ex, LineSearches.LineSearchException)
+                lssuccess = false
+                state.f_calls, state.g_calls = state.f_calls + ex.f_update, state.g_calls + ex.g_update
+                state.alpha = max(ex.alpha, 1e-12)
+                #state.alpha = ex.alpha
+                Base.warn("Linesearch failed, using alpha = $(state.alpha) and exiting optimization.")
+            else
+                rethrow(ex)
+            end
+        end
 
         # Maintain a record of previous position
         copy!(state.x_previous, state.x)
 
         # Update current position # x = x + alpha * s
         LinAlg.axpy!(state.alpha, state.s, state.x)
-        false
+        (lssuccess == false) # break on linesearch error
 end

--- a/src/newton.jl
+++ b/src/newton.jl
@@ -71,8 +71,7 @@ function initial_state{T}(method::Newton, options, d, initial_x::Array{T})
             if isa(ex, LineSearches.LineSearchException)
                 lssuccess = false
                 state.f_calls, state.g_calls = state.f_calls + ex.f_update, state.g_calls + ex.g_update
-                state.alpha = max(ex.alpha, 1e-12)
-                #state.alpha = ex.alpha
+                state.alpha = ex.alpha
                 Base.warn("Linesearch failed, using alpha = $(state.alpha) and exiting optimization.")
             else
                 rethrow(ex)

--- a/test/lsthrow.jl
+++ b/test/lsthrow.jl
@@ -1,0 +1,15 @@
+let
+    function ls(df,x,s,xtmp,g,lsr,c,mayterminate)
+        LineSearches.hagerzhang!(df,x,s,xtmp,g,lsr,c,mayterminate,
+                                 0.1,0.9,
+                                 Inf,5.,1e-6,0.66,
+                                 2)
+    end
+    for optimizer in (ConjugateGradient, GradientDescent, LBFGS, BFGS, Newton, AcceleratedGradientDescent, MomentumGradientDescent)
+        println("Testing $(string(optimizer))")
+        prob = Optim.UnconstrainedProblems.examples["Exponential"]
+        optimize(prob.f, prob.initial_x, optimizer(linesearch! = ls),
+                 OptimizationOptions(autodiff = true))
+        # TODO: How can I verify that the call to optimize gives a warning?
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ using Compat
 
 my_tests = [
     "types.jl",
+    "lsthrow.jl",
     "bfgs.jl",
     "gradient_descent.jl",
     "accelerated_gradient_descent.jl",


### PR DESCRIPTION
I've just added this as a WIP proposal for how to treat linesearch errors, to add to #263. Probably no reason to fully develop this until #266  is sorted.

I'm using this at the moment to get around the Error throw, as I'm only calling Optim in an inner loop of a solve that does not require very high tolerance.

TODO:
- [x] Deal with minimum linesearch step