### PR TITLE
Fixes solve_tr_subproblem!

### DIFF
--- a/src/newton_trust_region.jl
+++ b/src/newton_trust_region.jl
@@ -211,7 +211,7 @@ function solve_tr_subproblem!{T}(gr::Vector{T},
         end
     end
 
-    m = vecdot(gr, s) + 0.5 * vecdot(s, H_ridged * s)
+    m = vecdot(gr, s) + 0.5 * vecdot(s, H * s)
 
     return m, interior, lambda, hard_case, reached_solution
 end

--- a/src/newton_trust_region.jl
+++ b/src/newton_trust_region.jl
@@ -139,7 +139,7 @@ function solve_tr_subproblem!{T}(gr::Vector{T},
 
         # Solutions smaller than this lower bound on lambda are not allowed:
         # they don't ridge H enough to make H_ridge PSD.
-        lambda_lb = -min_H_ev + max(1e-4, abs(min_H_ev) * 1e-4)
+        lambda_lb = -min_H_ev + max(1e-8, 1e-8 * (max_H_ev - min_H_ev))
         lambda = lambda_lb
 
         hard_case = false

--- a/test/newton_trust_region.jl
+++ b/test/newton_trust_region.jl
@@ -1,4 +1,45 @@
 let
+    # verify that solve_tr_subproblem! finds the minimum
+    n = 2
+    gr = [-0.74637,0.52388]
+    H = [0.945787 -3.07884; -3.07884 -1.27762]
+
+    s = zeros(n)
+    m, interior = Optim.solve_tr_subproblem!(gr, H, 1., s, max_iters=100)
+
+    for j in 1:10
+        bad_s = rand(n)
+        bad_s ./= norm(bad_s)  # boundary
+        model(s2) = (gr' * s2)[] + .5 * (s2' * H * s2)[]
+        @assert model(s) <= model(bad_s) + 1e-8
+    end
+end
+
+let
+    # random Hessians--verify that solve_tr_subproblem! finds the minimum
+    for i in 1:10000
+        n = rand(1:10)
+        gr = randn(n)
+        H = randn(n, n)
+        H += H'
+
+        s = zeros(n)
+        m, interior = Optim.solve_tr_subproblem!(gr, H, 1., s, max_iters=100)
+
+        model(s2) = (gr' * s2)[] + .5 * (s2' * H * s2)[]
+        @assert model(s) <= model(zeros(n)) + 1e-8  # origin
+
+        for j in 1:10
+            bad_s = rand(n)
+            bad_s ./= norm(bad_s)  # boundary
+            @assert model(s) <= model(bad_s) + 1e-8
+            bad_s .*= rand()  # interior
+            @assert model(s) <= model(bad_s) + 1e-8
+        end
+    end
+end
+
+let
     #######################################
     # First test the subproblem.
     srand(42)


### PR DESCRIPTION
This PR adds unit tests for `solve_tr_subproblem!` based on randomly generated Hessians and gradients. For some indefinite Hessians, the tests fail.

This PR also includes a fix: `lambda_lb` does not need to be so large. With large values of `lambda_lb`, the trust region method finds interior solutions to the quadratic minimization problem when it should find a boundary solution. All tests pass with a smaller value for `lambda_lb`.

I've also verified that the fix doesn't break anything in the Celeste.jl package, which depends on the newton trust region code in Optim.jl, and may call `solve_tr_subproblem!` with Hessians that are more poorly conditioned than the Hessians these new unit tests generate at random.