### PR TITLE
Concerning optimisation of univariate functions using bracketing methods - Documentation

### DIFF
--- a/docs/src/user/minimization.md
+++ b/docs/src/user/minimization.md
@@ -117,6 +117,8 @@ In addition to the `iterations`, `store_trace`, `show_trace` and
 * `rel_tol`: The relative tolerance used for determining convergence. Defaults to `sqrt(eps(T))`.
 * `abs_tol`: The absolute tolerance used for determining convergence. Defaults to `eps(T)`.
 
+Important notice: the minimization of a univariate function in a bounded interval assumes that your function can be "bracketet" in the given interval. If this is not the case, optimisation of the univariate function may not necessarily yield a global minimum.
+
 ## Obtaining results
 After we have our results in `res`, we can use the API for getting optimization results.
 This consists of a collection of functions. They are not exported, so they have to be prefixed by `Optim.`.


### PR DESCRIPTION
I recently run into a little bug (in my own code) when optimising a univariate function using the optim package.

In particular I was optimising an upper bound which was expressed as the sum of univariate functions f_i.
These univariate functions were bounded but not necessarily unimodal.
Calling "optimize(f_i, L, U)" would hence sometimes lead to the upper bound becoming lower than higher.
I finally realised that the algorithm relies of course on being able to bracket the functions f_i; if this is not possible then just a local minimum will be found as opposed to a global minimum.

I think that this should be pointed out to users that do not realise that optimising a univariate function relies on being able to bracket it in a given interval.
