### PR TITLE
tweak showing optimization results

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -150,9 +150,9 @@ function Base.show(io::IO, r::MultivariateOptimizationResults)
         @printf io "   * |g(x)| < %.1e: %s\n" g_tol(r) g_converged(r)
     end
     @printf io "   * Reached Maximum Number of Iterations: %s\n" iteration_limit_reached(r)
-    @printf io " * Objective Function Calls: %d\n" f_calls(r)
+    @printf io " * Objective Function Calls: %d" f_calls(r)
     if !(r.method in ("Nelder-Mead", "Simulated Annealing"))
-        @printf io " * Gradient Calls: %d" g_calls(r)
+        @printf io "\n * Gradient Calls: %d" g_calls(r)
     end
     return
 end


### PR DESCRIPTION
This makes `show(results)` do not print a newline character at the end:
```
julia> r = optimize(rosenbrock, zeros(2))
Results of Optimization Algorithm
 * Algorithm: Nelder-Mead
 * Starting Point: [0.0,0.0]
 * Minimizer: [1.0000879002056393,1.0001763875092962]
 * Minimum: 7.760013e-09
 * Iterations: 74
 * Convergence: true
   *  √(Σ(yᵢ-ȳ)²)/n < 1.0e-08: true
   * Reached Maximum Number of Iterations: false
 * Objective Function Calls: 108

julia> r = optimize(rosenbrock, zeros(2), BFGS())
Results of Optimization Algorithm
 * Algorithm: BFGS
 * Starting Point: [0.0,0.0]
 * Minimizer: [0.9999999929485311,0.9999999859278653]
 * Minimum: 4.981810e-17
 * Iterations: 21
 * Convergence: true
   * |x - x'| < 1.0e-32: false
   * |f(x) - f(x')| / |f(x)| < 1.0e-32: true
   * |g(x)| < 1.0e-08: false
   * Reached Maximum Number of Iterations: false
 * Objective Function Calls: 157
 * Gradient Calls: 157

julia>
```