### PR TITLE
Test on nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
 julia:
     - 0.4
     - 0.5
+    - nightly
 notifications:
     email: false
 sudo: false


### PR DESCRIPTION
Currently tests aren't run on nightly so this can break downstream packages (like Gadfly)