### PR TITLE
Fix some bugs of the tracing for Nelder-Mead algorithm.

### DIFF
--- a/src/utilities/assess_convergence.jl
+++ b/src/utilities/assess_convergence.jl
@@ -53,7 +53,7 @@ function assess_convergence(state, options)
 end
 
 function assess_convergence(state::NelderMeadState, options)
-    g_converged = state.f_x <= options.g_tol # Hijact g_converged for NM stopping criterior
+    g_converged = state.nm_x <= options.g_tol # Hijact g_converged for NM stopping criterior
     return false, false, g_converged, g_converged
 end
 

--- a/src/utilities/trace.jl
+++ b/src/utilities/trace.jl
@@ -7,7 +7,7 @@ function trace!(tr, state, iteration, method::NelderMead, options)
     update!(tr,
     iteration,
     state.f_lowest,
-    state.f_x,
+    state.nm_x,
     dt,
     options.store_trace,
     options.show_trace,

--- a/test/api.jl
+++ b/test/api.jl
@@ -35,7 +35,7 @@ let
 
     Optim.optimize(d3, initial_x, method = Newton())
 
-   Optim.optimize(f, initial_x, method = SimulatedAnnealing())
+    Optim.optimize(f, initial_x, method = SimulatedAnnealing())
 
     optimize(f, initial_x, method = BFGS())
     optimize(f, initial_x, BFGS())
@@ -118,7 +118,7 @@ let
     	           iterations = 10,
     	           store_trace = true,
     	           show_trace = false)
-                   
+
    res_ext = optimize(f, g!, h!,
                       initial_x,
                       method = BFGS(),

--- a/test/nelder_mead.jl
+++ b/test/nelder_mead.jl
@@ -11,6 +11,11 @@ let
 		end
 		!(name == "Large Polynomial") && @assert norm(Optim.minimizer(res) - prob.solutions) < 1e-2
 	end
+
+    # Test if the trace is correctly stored.
+    prob = Optim.UnconstrainedProblems.examples["Rosenbrock"]
+    res = Optim.optimize(prob.f, prob.initial_x, method = NelderMead(), store_trace = true)
+    @assert ( length(unique(Optim.g_norm_trace(res))) != 1 || length(unique(Optim.f_trace(res))) != 1 ) && issorted(Optim.f_trace(res)[end:1])
 end
 
 


### PR DESCRIPTION
This pull request is intended to fix the tracing for Nelder-Mead algorithm. Currently, `show_trace` for Nelder-Mead is showing the same function values for all iterations because `state.f_lowest` is not updated. In addition to the fix of this bug, I have updated the variable names as suggested in this comment.
> f_x and f_x_previous should be renamed to nm_x, nm_x_previous and f_x should hold
-# f_lowest instead!

On a side note, `f_lowest` and `f_x` should hold the same values during the iterations, but I am updating only `f_lowest` by following how `trace!` is currently implemented. I have also removed `f_x_previous` because it was not used.

I hope this update reflects the intention of the comment.