### PR TITLE
BFGS and Newton: reset initial linesearch step to one

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# Optim (unversioned) release notes
+* Newton and BFGS: set initial step length to one.
+See [328](https://github.com/JuliaOpt/Optim.jl/pull/328).
+
 # Optim v0.7.3 release notes
 * OptimizationOptions is now unexported, and has been renamed to Options. Must be accessed as Optim.Options as a result.
 * Bug fixes to Nelder-Mead tracing.

--- a/docs/src/algo/lbfgs.md
+++ b/docs/src/algo/lbfgs.md
@@ -4,7 +4,8 @@ This page contains information about BFGS and its limited memory version L-BFGS.
 ```julia
 BFGS(; linesearch = LineSearches.hagerzhang!,
        P = nothing,
-       precondprep = (P, x) -> nothing)
+       precondprep = (P, x) -> nothing,
+       resetalpha = true)
 ```
 
 ```julia
@@ -38,6 +39,9 @@ as follows
 $ x_{n+1} = x_n - \alpha P^{-1}\nabla f(x_n)$
 
 and is chosen by a linesearch algorithm such that each step gives sufficient descent.
+
+**For BFGS only**: If `resetalpha = true`, the linesearch algorithm starts with the initial value $ \alpha = 1.0 $ for each new BFGS iteration. Otherwise, it will use the terminating value of $ \alpha $ from the previous BFGS iteration.
+
 ## Example
 ## References
 Wright, Stephen, and Jorge Nocedal (2006) "Numerical optimization." Springer

--- a/docs/src/algo/newton.md
+++ b/docs/src/algo/newton.md
@@ -1,12 +1,14 @@
 # Newton's Method
 ## Constructor
 ```julia
-Newton(; linesearch = LineSearches.hagerzhang!)
+Newton(; linesearch = LineSearches.hagerzhang!,
+         resetalpha = true)
 ```
 
-The constructor takes one keyword
+The constructor takes two keywords:
 
 * `linesearch = a(d, x, p, x_new, g_new, lsr, c, mayterminate)`, a function performing line search, see the line search section.
+* `resetalpha`, a boolean flag that determines, for each new search direction, whether the initial line search step length should be reset to 1.0, or kept as in the previous Newton iteration.
 
 ## Description
 Newton's method for optimization has a long history, and is in some sense the

--- a/src/newton.jl
+++ b/src/newton.jl
@@ -1,14 +1,17 @@
 immutable Newton <: Optimizer
     linesearch!::Function
+    resetalpha::Bool
 end
 #= uncomment v0.8.0
 Newton(; linesearch::Function = LineSearches.hagerzhang!) =
-  Newton(linesearch)
+Newton(linesearch)
 =#
-function Newton(; linesearch! = nothing, linesearch::Function = LineSearches.hagerzhang!)
+function Newton(; linesearch! = nothing, linesearch::Function = LineSearches.hagerzhang!,
+                resetalpha = true)
     linesearch = get_linesearch(linesearch!, linesearch)
-    Newton(linesearch)
+    Newton(linesearch,resetalpha)
 end
+
 type NewtonState{T}
     @add_generic_fields()
     x_previous::Array{T}
@@ -22,70 +25,73 @@ type NewtonState{T}
 end
 
 function initial_state{T}(method::Newton, options, d, initial_x::Array{T})
-        n = length(initial_x)
-      # Maintain current gradient in gr
-      g = Array(T, n)
-      s = Array(T, n)
-      x_ls, g_ls = Array(T, n), Array(T, n)
-      f_x_previous, f_x = NaN, d.fg!(initial_x, g)
-      f_calls, g_calls = 1, 1
-      H = Array(T, n, n)
-      d.h!(initial_x, H)
-      h_calls = 1
+    n = length(initial_x)
+    # Maintain current gradient in gr
+    g = Array(T, n)
+    s = Array(T, n)
+    x_ls, g_ls = Array(T, n), Array(T, n)
+    f_x_previous, f_x = NaN, d.fg!(initial_x, g)
+    f_calls, g_calls = 1, 1
+    H = Array(T, n, n)
+    d.h!(initial_x, H)
+    h_calls = 1
 
-      NewtonState("Newton's Method",
-                  length(initial_x),
-                  copy(initial_x), # Maintain current state in state.x
-                  f_x, # Store current f in state.f_x
-                  f_calls, # Track f calls in state.f_calls
-                  g_calls, # Track g calls in state.g_calls
-                  h_calls,
-                  copy(initial_x), # Maintain current state in state.x_previous
-                  g, # Store current gradient in state.g
-                  T(NaN), # Store previous f in state.f_x_previous
-                  H,
-                  copy(H),
-                  copy(H),
-                  similar(initial_x), # Maintain current search direction in state.s
-                  @initial_linesearch()...) # Maintain a cache for line search results in state.lsr
-  end
+    NewtonState("Newton's Method",
+                length(initial_x),
+                copy(initial_x), # Maintain current state in state.x
+                f_x, # Store current f in state.f_x
+                f_calls, # Track f calls in state.f_calls
+                g_calls, # Track g calls in state.g_calls
+                h_calls,
+                copy(initial_x), # Maintain current state in state.x_previous
+                g, # Store current gradient in state.g
+                T(NaN), # Store previous f in state.f_x_previous
+                H,
+                copy(H),
+                copy(H),
+                similar(initial_x), # Maintain current search direction in state.s
+                @initial_linesearch()...) # Maintain a cache for line search results in state.lsr
+end
 
-  function update_state!{T}(d, state::NewtonState{T}, method::Newton)
-        lssuccess = true
-        # Search direction is always the negative gradient divided by
-        # a matrix encoding the absolute values of the curvatures
-        # represented by H. It deviates from the usual "add a scaled
-        # identity matrix" version of the modified Newton method. More
-        # information can be found in the discussion at issue #153.
-        state.F, state.Hd = ldltfact!(Positive, state.H)
-        state.s[:] = -(state.F\state.g)
+function update_state!{T}(d, state::NewtonState{T}, method::Newton)
+    lssuccess = true
+    # Search direction is always the negative gradient divided by
+    # a matrix encoding the absolute values of the curvatures
+    # represented by H. It deviates from the usual "add a scaled
+    # identity matrix" version of the modified Newton method. More
+    # information can be found in the discussion at issue #153.
+    state.F, state.Hd = ldltfact!(Positive, state.H)
+    state.s[:] = -(state.F\state.g)
 
-        # Refresh the line search cache
-        dphi0 = vecdot(state.g, state.s)
-        LineSearches.clear!(state.lsr)
-        push!(state.lsr, zero(T), state.f_x, dphi0)
+    # Refresh the line search cache
+    dphi0 = vecdot(state.g, state.s)
+    LineSearches.clear!(state.lsr)
+    push!(state.lsr, zero(T), state.f_x, dphi0)
 
-        # Determine the distance of movement along the search line
-        try
-            state.alpha, f_update, g_update =
-                method.linesearch!(d, state.x, state.s, state.x_ls, state.g_ls, state.lsr,
-                                   state.alpha, state.mayterminate)
-            state.f_calls, state.g_calls = state.f_calls + f_update, state.g_calls + g_update
-        catch ex
-            if isa(ex, LineSearches.LineSearchException)
-                lssuccess = false
-                state.f_calls, state.g_calls = state.f_calls + ex.f_update, state.g_calls + ex.g_update
-                state.alpha = ex.alpha
-                Base.warn("Linesearch failed, using alpha = $(state.alpha) and exiting optimization.")
-            else
-                rethrow(ex)
-            end
+    # Determine the distance of movement along the search line
+    try
+        if method.resetalpha == true
+            state.alpha = one(T)
         end
+        state.alpha, f_update, g_update =
+            method.linesearch!(d, state.x, state.s, state.x_ls, state.g_ls, state.lsr,
+                               state.alpha, state.mayterminate)
+        state.f_calls, state.g_calls = state.f_calls + f_update, state.g_calls + g_update
+    catch ex
+        if isa(ex, LineSearches.LineSearchException)
+            lssuccess = false
+            state.f_calls, state.g_calls = state.f_calls + ex.f_update, state.g_calls + ex.g_update
+            state.alpha = ex.alpha
+            Base.warn("Linesearch failed, using alpha = $(state.alpha) and exiting optimization.")
+        else
+            rethrow(ex)
+        end
+    end
 
-        # Maintain a record of previous position
-        copy!(state.x_previous, state.x)
+    # Maintain a record of previous position
+    copy!(state.x_previous, state.x)
 
-        # Update current position # x = x + alpha * s
-        LinAlg.axpy!(state.alpha, state.s, state.x)
-        (lssuccess == false) # break on linesearch error
+    # Update current position # x = x + alpha * s
+    LinAlg.axpy!(state.alpha, state.s, state.x)
+    (lssuccess == false) # break on linesearch error
 end

--- a/test/api.jl
+++ b/test/api.jl
@@ -109,11 +109,11 @@ let
                        options_ext)
 
    @test Optim.method(res) == "BFGS"
-   @test Optim.minimum(res) ≈ 0.055119582904897345
-   @test Optim.minimizer(res) ≈ [0.7731690866149542; 0.5917345966396391]
+   @test isapprox(Optim.minimum(res), 0.0020622412076141045; rtol=1e-3)
+   @test isapprox(Optim.minimizer(res), [0.9719007353489979,0.9410235857510793]; rtol=1e-3)
    @test Optim.iterations(res) == 10
-   @test Optim.f_calls(res) == 48
-   @test Optim.g_calls(res) == 48
+   @test Optim.f_calls(res) == 47
+   @test Optim.g_calls(res) == 47
    @test Optim.converged(res) == false
    @test Optim.x_converged(res) == false
    @test Optim.f_converged(res) == false

--- a/test/newton.jl
+++ b/test/newton.jl
@@ -59,7 +59,7 @@ let
         prob=Optim.UnconstrainedProblems.examples["Himmelblau"]
         ddf = TwiceDifferentiableFunction(prob.f, prob.g!, prob.h!)
         res = optimize(ddf, [0., 0.], Newton())
-        @assert norm(Optim.minimizer(res) - prob.solutions) < 1e-10
+        @assert norm(Optim.minimizer(res) - prob.solutions) < 1e-9
     end
 
 


### PR DESCRIPTION
Resetting the initial step for the linesearch to one after each iteration in Newton and BFGS improves convergence: 
Newton CUTEst tests with maxvar = 5:
![f_err_cutest](https://cloud.githubusercontent.com/assets/5601805/21455516/c19d770a-c918-11e6-82b9-d619f55d4bf2.png)
BFGS CUTEst tests with maxvar = 5:
![f_err_bfgs_cutest](https://cloud.githubusercontent.com/assets/5601805/21455527/d82246c2-c918-11e6-8600-babaf56322b4.png)

BT3 is backtracking with cubic interpolation, added in anriseth/LineSearches.jl#20. The behaviour for quadratic bactracking is similar.
LBFGS already has a variant of this implemented, so I haven't added it there.
Ref #91 