### PR TITLE
Enable AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,35 @@
+environment:
+  matrix:
+    - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
+    - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
+matrix:
+  allow_failures:
+    - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
+    - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
+branches:
+  only:
+    - master
+    - /release-.*/
+
+notifications:
+  - provider: Email
+    on_build_success: false
+    on_build_failure: false
+    on_build_status_changed: false
+
+install:
+# Download most recent Julia Windows binary
+  - ps: (new-object net.webclient).DownloadFile(
+        $("http://s3.amazonaws.com/"+$env:JULIAVERSION),
+        "C:\projects\julia-binary.exe")
+# Run installer silently, output to C:\projects\julia
+  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+
+build_script:
+# Need to convert from shallow to complete for Pkg.clone to work
+  - IF EXIST .git\shallow (git fetch --unshallow)
+  - C:\projects\julia\bin\julia -e "versioninfo();
+      Pkg.clone(pwd(), \"Optim\"); Pkg.build(\"Optim\")"
+
+test_script:
+  - C:\projects\julia\bin\julia -e "Pkg.test(\"Optim\")"


### PR DESCRIPTION
Optim.jl has failures on Windows which are undetected by the devs because Windows CI is not enabled. As a large package in the Julia package ecosystem which has no binary dependencies, it should be easy to test and support Windows. This PR adds an appveyor.yml file to do just that, but does not enable CI because I can't do that (you have to be in the org). I would be willing to take the CI burden if you want (Orgs cannot have CI for AppVeyor). (I would have to be added to the org to do that though.)

For current failures, see https://github.com/JuliaOpt/Optim.jl/issues/332