### PR TITLE
Remove Int64

### DIFF
--- a/src/accelerated_gradient_descent.jl
+++ b/src/accelerated_gradient_descent.jl
@@ -26,7 +26,7 @@ type AcceleratedGradientDescentState{T}
     x_previous::Array{T}
     g::Array{T}
     f_x_previous::T
-    iteration::Int64
+    iteration::Int
     y::Array{T}
     y_previous::Array{T}
     s::Array{T}

--- a/src/l_bfgs.jl
+++ b/src/l_bfgs.jl
@@ -103,7 +103,7 @@ type LBFGSState{T}
     f_x_previous::T
     twoloop_q
     twoloop_alpha
-    pseudo_iteration::Int64
+    pseudo_iteration::Int
     s::Array{T}
     @add_linesearch_fields()
 end

--- a/src/nelder_mead.jl
+++ b/src/nelder_mead.jl
@@ -105,7 +105,7 @@ end
 
 type NelderMeadState{T, N}
     @add_generic_fields()
-    m::Int64
+    m::Int
     simplex::Vector{Array{T,N}}
     x_centroid::Array{T}
     x_lowest::Array{T}
@@ -116,7 +116,7 @@ type NelderMeadState{T, N}
     f_simplex::Array{T}
     nm_x::T
     f_lowest::T
-    i_order::Vector{Int64}
+    i_order::Vector{Int}
     α::T
     β::T
     γ::T

--- a/src/particle_swarm.jl
+++ b/src/particle_swarm.jl
@@ -8,14 +8,14 @@ ParticleSwarm(; lower = [], upper = [], n_particles = 0) = ParticleSwarm(lower, 
 
 type ParticleSwarmState{T}
     @add_generic_fields()
-    iteration::Int64
+    iteration::Int
     lower
     upper
     c1::T # Weight variable; currently not exposed to users
     c2::T # Weight variable; currently not exposed to users
     w::T  # Weight variable; currently not exposed to users
     limit_search_space::Bool
-    n_particles::Int64
+    n_particles::Int
     X
     V
     X_best

--- a/src/simulated_annealing.jl
+++ b/src/simulated_annealing.jl
@@ -23,7 +23,7 @@ SimulatedAnnealing(; neighbor!::Function = default_neighbor!,
 
 type SimulatedAnnealingState{T}
     @add_generic_fields()
-    iteration::Int64
+    iteration::Int
     x_current::Array{T}
     x_proposal
     f_x_current::T

--- a/src/utilities/generic.jl
+++ b/src/utilities/generic.jl
@@ -9,12 +9,12 @@ end
 # TODO decide if this is wanted and/or necessary
 @def add_generic_fields begin
     method_string::String
-    n::Int64
+    n::Int
     x::Array{T}
     f_x::T
-    f_calls::Int64
-    g_calls::Int64
-    h_calls::Int64
+    f_calls::Int
+    g_calls::Int
+    h_calls::Int
 end
 
 @def add_linesearch_fields begin


### PR DESCRIPTION
This is usually a good idea for handling Win32 since it fixes the issue that

```julia
type A
  a::Int64
end 
A(1)
```

throws an error, and 

```julia
f(i::Int64) = 2
f(1)
```

throw an error on 32-bit systems. Given the changes that were made, it seems this may be all that's needed to fix Win32, but AppVeyor will be the one to let us know.

Could potentially fix https://github.com/JuliaOpt/Optim.jl/issues/332