### PR TITLE
Change all tests to testsets and suppress some information by default.

### DIFF
--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,1 @@
+BaseTestNext

--- a/test/accelerated_gradient_descent.jl
+++ b/test/accelerated_gradient_descent.jl
@@ -1,5 +1,5 @@
 # TODO expand tests here
-let
+@testset "Accelerated Gradient Descent" begin 
     f(x) = x[1]^4
     function g!(x, storage)
         storage[1] = 4 * x[1]^3

--- a/test/api.jl
+++ b/test/api.jl
@@ -1,5 +1,5 @@
 # Test multivariate optimization
-let
+@testset "API" begin
     rosenbrock = Optim.UnconstrainedProblems.examples["Rosenbrock"]
     f = rosenbrock.f
     g! = rosenbrock.g!

--- a/test/api.jl
+++ b/test/api.jl
@@ -1,5 +1,5 @@
 # Test multivariate optimization
-@testset "API" begin
+@testset "Multivariate API" begin
     rosenbrock = Optim.UnconstrainedProblems.examples["Rosenbrock"]
     f = rosenbrock.f
     g! = rosenbrock.g!
@@ -148,7 +148,7 @@
 end
 
 # Test univariate API
-let
+@testset "Univariate API" begin
     f(x) = 2x^2+3x+1
     res = optimize(f, -2.0, 1.0, GoldenSection())
     @test Optim.method(res) == "Golden Section Search"

--- a/test/array.jl
+++ b/test/array.jl
@@ -1,4 +1,4 @@
-let
+@testset "Matrix input" begin
     f(X) = (10 - X[1, 1])^2 + (0 - X[1, 2])^2 + (0 - X[2, 1])^2 + (5 - X[2, 2])^2
 
     function g!(X, S)

--- a/test/bfgs.jl
+++ b/test/bfgs.jl
@@ -1,10 +1,10 @@
-let
+@testset "BFGS" begin
     for use_autodiff in (false, true)
         for (name, prob) in Optim.UnconstrainedProblems.examples
             if prob.isdifferentiable
                 f_prob = prob.f
                 res = Optim.optimize(f_prob, prob.initial_x, BFGS(), Optim.Options(autodiff = use_autodiff))
-                @assert norm(Optim.minimizer(res) - prob.solutions) < 1e-2
+                @test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
             end
         end
     end

--- a/test/brent.jl
+++ b/test/brent.jl
@@ -1,10 +1,10 @@
-let
+@testset "Brent's Method" begin
     for (name, prob) in Optim.UnivariateProblems.examples
         for T in (Float64, BigFloat)
             results = optimize(prob.f, convert(Array{T}, prob.bounds)..., method = Brent())
 
-            @assert Optim.converged(results)
-            @assert norm(Optim.minimizer(results) - prob.minimizers) < 1e-7
+            @test Optim.converged(results)
+            @test norm(Optim.minimizer(results) - prob.minimizers) < 1e-7
         end
     end
 end

--- a/test/callbacks.jl
+++ b/test/callbacks.jl
@@ -1,4 +1,4 @@
-let
+@testset "Callbacks" begin
     problem = Optim.UnconstrainedProblems.examples["Rosenbrock"]
 
     f = problem.f

--- a/test/cg.jl
+++ b/test/cg.jl
@@ -1,10 +1,10 @@
-let
+@testset "Conjugate Gradient" begin
 	# Test Optim.cg for all differentiable functions in Optim.UnconstrainedProblems.examples
 	for (name, prob) in Optim.UnconstrainedProblems.examples
 		if prob.isdifferentiable
 			df = DifferentiableFunction(prob.f, prob.g!)
 			res = Optim.optimize(df, prob.initial_x, ConjugateGradient())
-				@assert norm(Optim.minimizer(res) - prob.solutions) < 1e-2
+				@test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
 		end
 	end
 
@@ -21,7 +21,7 @@ let
 	B = rand(2,2)
 	df = Optim.DifferentiableFunction(X -> objective(X, B), (X, G) -> objective_gradient!(X, G, B))
 	results = Optim.optimize(df, rand(2,2), ConjugateGradient())
-	@assert Optim.converged(results)
-	@assert Optim.minimum(results) < 1e-8
+	@test Optim.converged(results)
+	@test Optim.minimum(results) < 1e-8
 	end
 end

--- a/test/constrained.jl
+++ b/test/constrained.jl
@@ -1,4 +1,4 @@
-let
+@testset "Constrained" begin
     # Quadratic objective function
     # For (A*x-b)^2/2
     function quadratic!(x, g, AtA, Atb, tmp)

--- a/test/extrapolate.jl
+++ b/test/extrapolate.jl
@@ -1,41 +1,47 @@
-
 import LineSearches
 
 @testset "Extrapolation" begin
-   methods = [ LBFGS(), ConjugateGradient(),
-               LBFGS(extrapolate=true, linesearch = LineSearches.bt2!) ]
-   msgs = ["LBFGS Default Options: ",  "CG Default Options: ",
-          "LBFGS + Backtracking + Extrapolation: " ]
+    methods = [LBFGS(),
+               ConjugateGradient(),
+               LBFGS(extrapolate=true, linesearch = LineSearches.bt2!)]
+    msgs = ["LBFGS Default Options: ",
+            "CG Default Options: ",
+            "LBFGS + Backtracking + Extrapolation: "]
 
-   println("--------------------")
-   println("Rosenbrock Example: ")
-   println("--------------------")
-   rosenbrock(x) =  (1.0 - x[1])^2 + 100.0 * (x[2] - x[1]^2)^2
-   for (method, msg) in zip(methods, msgs)
-      results = Optim.optimize(rosenbrock, zeros(2), method)
-      println(msg, "g_calls = ", results.g_calls, ", f_calls = ", results.f_calls)
-   end
+    if debug_printing
+        println("--------------------")
+        println("Rosenbrock Example: ")
+        println("--------------------")
+    end
+    rosenbrock(x) =  (1.0 - x[1])^2 + 100.0 * (x[2] - x[1]^2)^2
+    for (method, msg) in zip(methods, msgs)
+        results = Optim.optimize(rosenbrock, zeros(2), method)
+        debug_printing && println(msg, "g_calls = ", results.g_calls, ", f_calls = ", results.f_calls)
+    end
 
-   println("--------------------------------------")
-   println("p-Laplacian Example (preconditioned): ")
-   println("--------------------------------------")
-   plap(U; n=length(U)) = (n-1) * sum( (0.1 + diff(U).^2).^2 ) - sum(U) / (n-1)
-   plap1(U; n=length(U), dU = diff(U), dW = 4 * (0.1 + dU.^2) .* dU) =
-                           (n-1) * ([0.0; dW] - [dW; 0.0]) - ones(U) / (n-1)
-   precond(x::Vector) = precond(length(x))
-   precond(n::Number) = spdiagm( ( -ones(n-1), 2*ones(n), -ones(n-1) ),
-                                 (-1,0,1), n, n) * (n+1)
-   df = DifferentiableFunction( X->plap([0;X;0]),
+    if debug_printing
+        println("--------------------------------------")
+        println("p-Laplacian Example (preconditioned): ")
+        println("--------------------------------------")
+    end
+    plap(U; n=length(U)) = (n-1) * sum( (0.1 + diff(U).^2).^2 ) - sum(U) / (n-1)
+    plap1(U; n=length(U), dU = diff(U), dW = 4 * (0.1 + dU.^2) .* dU) =
+                            (n-1) * ([0.0; dW] - [dW; 0.0]) - ones(U) / (n-1)
+    precond(x::Vector) = precond(length(x))
+    precond(n::Number) = spdiagm(( -ones(n-1), 2*ones(n), -ones(n-1) ),
+                         (-1,0,1), n, n) * (n+1)
+    df = DifferentiableFunction( X->plap([0;X;0]),
                                 (X, G)->copy!(G, (plap1([0;X;0]))[2:end-1]) )
-   GRTOL = 1e-6
-   N = 100
-   initial_x = zeros(N)
-   P = precond(initial_x)
-   methods = [ LBFGS(P=P), ConjugateGradient(P=P),
-         LBFGS(extrapolate=true, linesearch = LineSearches.bt2!, P=P) ]
+    GRTOL = 1e-6
+    N = 100
+    initial_x = zeros(N)
+    P = precond(initial_x)
+    methods = [LBFGS(P=P),
+               ConjugateGradient(P=P),
+               LBFGS(extrapolate=true, linesearch = LineSearches.bt2!, P=P)]
 
-   for (method, msg) in zip(methods, msgs)
-      results = Optim.optimize(df, copy(initial_x), method)
-      println(msg, "g_calls = ", Optim.g_calls(results), ", f_calls = ", Optim.f_calls(results))
-   end
+    for (method, msg) in zip(methods, msgs)
+        results = Optim.optimize(df, copy(initial_x), method)
+        debug_printing && println(msg, "g_calls = ", Optim.g_calls(results), ", f_calls = ", Optim.f_calls(results))
+    end
 end

--- a/test/extrapolate.jl
+++ b/test/extrapolate.jl
@@ -1,9 +1,9 @@
 
 import LineSearches
 
-let
+@testset "Extrapolation" begin
    methods = [ LBFGS(), ConjugateGradient(),
-               LBFGS(extrapolate=true, linesearch = LineSearches.interpbacktrack!) ]
+               LBFGS(extrapolate=true, linesearch = LineSearches.bt2!) ]
    msgs = ["LBFGS Default Options: ",  "CG Default Options: ",
           "LBFGS + Backtracking + Extrapolation: " ]
 
@@ -32,10 +32,10 @@ let
    initial_x = zeros(N)
    P = precond(initial_x)
    methods = [ LBFGS(P=P), ConjugateGradient(P=P),
-         LBFGS(extrapolate=true, linesearch = LineSearches.interpbacktrack!, P=P) ]
+         LBFGS(extrapolate=true, linesearch = LineSearches.bt2!, P=P) ]
 
    for (method, msg) in zip(methods, msgs)
       results = Optim.optimize(df, copy(initial_x), method)
-      println(msg, "g_calls = ", results.g_calls, ", f_calls = ", results.f_calls)
+      println(msg, "g_calls = ", Optim.g_calls(results), ", f_calls = ", Optim.f_calls(results))
    end
 end

--- a/test/golden_section.jl
+++ b/test/golden_section.jl
@@ -1,11 +1,11 @@
-let
+@testset "Golden Section" begin
     for (name, prob) in Optim.UnivariateProblems.examples
         for T in (Float64, BigFloat)
             results = optimize(prob.f, convert(Array{T}, prob.bounds)...,
                                method = GoldenSection())
 
-            @assert Optim.converged(results)
-            @assert norm(Optim.minimizer(results) - prob.minimizers) < 1e-7
+            @test Optim.converged(results)
+            @test norm(Optim.minimizer(results) - prob.minimizers) < 1e-7
         end
     end
 end

--- a/test/gradient_descent.jl
+++ b/test/gradient_descent.jl
@@ -1,4 +1,4 @@
-let
+@testset "Gradient Descent" begin
     for use_autodiff in (false, true)
         for (name, prob) in Optim.UnconstrainedProblems.examples
             if prob.isdifferentiable
@@ -13,7 +13,7 @@ let
                 res = Optim.optimize(f_prob, prob.initial_x, GradientDescent(),
                                      Optim.Options(autodiff = use_autodiff,
                                                          iterations = iterations))
-                @assert norm(Optim.minimizer(res) - prob.solutions, Inf) < 1e-2
+                @test norm(Optim.minimizer(res) - prob.solutions, Inf) < 1e-2
             end
         end
     end
@@ -32,8 +32,8 @@ let
 
     results = Optim.optimize(d, initial_x, GradientDescent())
     @test_throws ErrorException Optim.x_trace(results)
-    @assert Optim.g_converged(results)
-    @assert norm(Optim.minimizer(results) - [5.0]) < 0.01
+    @test Optim.g_converged(results)
+    @test norm(Optim.minimizer(results) - [5.0]) < 0.01
 
     eta = 0.9
 
@@ -50,6 +50,6 @@ let
 
     results = Optim.optimize(d, [1.0, 1.0], GradientDescent())
     @test_throws ErrorException Optim.x_trace(results)
-    @assert Optim.g_converged(results)
-    @assert norm(Optim.minimizer(results) - [0.0, 0.0]) < 0.01
+    @test Optim.g_converged(results)
+    @test norm(Optim.minimizer(results) - [0.0, 0.0]) < 0.01
 end

--- a/test/grid_search.jl
+++ b/test/grid_search.jl
@@ -1,4 +1,5 @@
-Optim.grid_search(x -> (1.0 - x)^2, [-1:0.1:1.0;])
-
+@testset "Grid Search" begin
+    @test Optim.grid_search(x -> (1.0 - x)^2, [-1:0.1:1.0;]) == 1
+end
 # Cartesian product over 2 dimensions.
 #grid_search(x -> (1.0 - x[1])^2 + (2.0 - x[2])^2, product[-1:0.1:1.0, -1:0.1:1.0])

--- a/test/initial_convergence.jl
+++ b/test/initial_convergence.jl
@@ -1,4 +1,4 @@
-let
+@testset "Initial Convergence Handling" begin
     f(x) = x[1]^2
     function g!(x, out)
         out[1] = 2.*x[1]
@@ -11,11 +11,11 @@ let
                       MomentumGradientDescent)
 
         res = optimize(f, g!, [0.], Optimizer())
-        @assert isapprox(Optim.minimizer(res)[1], 0.)
+        @test isapprox(Optim.minimizer(res)[1], 0.)
     end
 
     for Optimizer in (Newton, NewtonTrustRegion)
         res = optimize(f, g!, h!, [0.], Optimizer())
-        @assert isapprox(Optim.minimizer(res)[1], 0.)
+        @test isapprox(Optim.minimizer(res)[1], 0.)
     end
 end

--- a/test/l_bfgs.jl
+++ b/test/l_bfgs.jl
@@ -1,10 +1,10 @@
-let
+@testset "L-BFGS" begin
     for use_autodiff in (false, true)
         for (name, prob) in Optim.UnconstrainedProblems.examples
             if prob.isdifferentiable
                 f_prob = prob.f
                 res = Optim.optimize(f_prob, prob.initial_x, LBFGS(), Optim.Options(autodiff = use_autodiff))
-                @assert norm(Optim.minimizer(res) - prob.solutions) < 1e-2
+                @test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
             end
         end
     end

--- a/test/levenberg_marquardt.jl
+++ b/test/levenberg_marquardt.jl
@@ -1,4 +1,4 @@
-let
+@testset "Levenberg Marquardt" begin
     function f_lm(x)
       [x[1], 2.0 - x[2]]
     end
@@ -9,7 +9,7 @@ let
     initial_x = [100.0, 100.0]
 
     results = Optim.levenberg_marquardt(f_lm, g_lm, initial_x)
-    @assert norm(Optim.minimizer(results) - [0.0, 2.0]) < 0.01
+    @test norm(Optim.minimizer(results) - [0.0, 2.0]) < 0.01
 
 
     function rosenbrock_res(x, r)
@@ -36,7 +36,7 @@ let
 
     results = Optim.levenberg_marquardt(frb, grb, initial_xrb)
 
-    @assert norm(Optim.minimizer(results) - [1.0, 1.0]) < 0.01
+    @test norm(Optim.minimizer(results) - [1.0, 1.0]) < 0.01
 
     # check estimate is within the bound PR #278
      result = Optim.levenberg_marquardt(frb, grb, [150.0, 150.0]; lower = [10.0, 10.0], upper = [200.0, 200.0])
@@ -59,7 +59,7 @@ let
         g_lsq = Calculus.jacobian(f_lsq)
         results = Optim.levenberg_marquardt(f_lsq, g_lsq, [0.5, 0.5])
 
-        @assert norm(Optim.minimizer(results) - [1.0, 2.0]) < 0.05
+        @test norm(Optim.minimizer(results) - [1.0, 2.0]) < 0.05
     end
 
     let

--- a/test/lsthrow.jl
+++ b/test/lsthrow.jl
@@ -1,4 +1,4 @@
-let
+@testset "Line search errors" begin
     function ls(df,x,s,xtmp,g,lsr,c,mayterminate)
         LineSearches.hagerzhang!(df,x,s,xtmp,g,lsr,c,mayterminate,
                                  0.1,0.9,

--- a/test/momentum_gradient_descent.jl
+++ b/test/momentum_gradient_descent.jl
@@ -1,18 +1,13 @@
-debug = false
-let
+@testset "Momentum Gradient Descent" begin
     for use_autodiff in (false, true)
         for (name, prob) in Optim.UnconstrainedProblems.examples
             if prob.isdifferentiable && !(name in ("Polynomial", "Large Polynomial", "Himmelblau")) # it goes in a direction of ascent -> f_converged == true
-                debug && @ show "** Name: $name"
                 f_prob = prob.f
                 iterations = name == "Powell" ? 2000 : 1000
                 res = Optim.optimize(f_prob, prob.initial_x, MomentumGradientDescent(),
                                      Optim.Options(autodiff = use_autodiff,
-                                                         iterations = iterations,
-                                                         show_trace = debug))
-                debug && @show Optim.minimizer(res)
-                debug && @show prob.solutions
-                @assert norm(Optim.minimizer(res) - prob.solutions, Inf) < 1e-2
+                                                         iterations = iterations))
+                @test norm(Optim.minimizer(res) - prob.solutions, Inf) < 1e-2
             end
         end
     end

--- a/test/nelder_mead.jl
+++ b/test/nelder_mead.jl
@@ -1,4 +1,4 @@
-let
+@testset "Nelder Mead" begin
 	# Test Optim.nelder_mead for all functions except Large Polynomials in Optim.UnconstrainedProblems.examples
 	for (name, prob) in Optim.UnconstrainedProblems.examples
 		f_prob = prob.f
@@ -9,11 +9,11 @@ let
 			# TODO do this only when a "run all" flag checked
 			# res = Optim.optimize(f_prob, prob.initial_x, method=NelderMead(initial_simplex = Optim.AffineSimplexer(1.,1.)), iterations = 450_000)
 		end
-		!(name == "Large Polynomial") && @assert norm(Optim.minimizer(res) - prob.solutions) < 1e-2
+		!(name == "Large Polynomial") && @test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
 	end
 
     # Test if the trace is correctly stored.
     prob = Optim.UnconstrainedProblems.examples["Rosenbrock"]
     res = Optim.optimize(prob.f, prob.initial_x, method = NelderMead(), store_trace = true)
-    @assert ( length(unique(Optim.g_norm_trace(res))) != 1 || length(unique(Optim.f_trace(res))) != 1 ) && issorted(Optim.f_trace(res)[end:1])
+    @test ( length(unique(Optim.g_norm_trace(res))) != 1 || length(unique(Optim.f_trace(res))) != 1 ) && issorted(Optim.f_trace(res)[end:1])
 end

--- a/test/newton.jl
+++ b/test/newton.jl
@@ -47,12 +47,14 @@
     @test norm(Optim.minimizer(results) - [0.0, 0.0]) < 0.01
 
     # Test Optim.newton for all twice differentiable functions in Optim.UnconstrainedProblems.examples
-    for (name, prob) in Optim.UnconstrainedProblems.examples
-    	if prob.istwicedifferentiable
-    		ddf = TwiceDifferentiableFunction(prob.f, prob.g!,prob.h!)
-    		res = Optim.optimize(ddf, prob.initial_x, Newton())
-    		@test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
-    	end
+    @testset "Optim problems" begin
+        for (name, prob) in Optim.UnconstrainedProblems.examples
+        	if prob.istwicedifferentiable
+        		ddf = TwiceDifferentiableFunction(prob.f, prob.g!,prob.h!)
+        		res = Optim.optimize(ddf, prob.initial_x, Newton())
+        		@test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
+        	end
+        end
     end
 
     let
@@ -62,16 +64,17 @@
         @test norm(Optim.minimizer(res) - prob.solutions) < 1e-9
     end
 
-
-    for (name, prob) in Optim.UnconstrainedProblems.examples
-    	if prob.istwicedifferentiable
-    		ddf = DifferentiableFunction(prob.f, prob.g!)
-    		res = Optim.optimize(ddf, prob.initial_x, Newton(), Optim.Options(autodiff = true))
-    		@test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
-    		res = Optim.optimize(ddf.f, prob.initial_x, Newton(), Optim.Options(autodiff = true))
-    		@test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
-            res = Optim.optimize(ddf.f, ddf.g!, prob.initial_x, Newton(), Optim.Options(autodiff = true))
-    		@test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
-    	end
+    @testset "Optim problems (ForwardDiff)" begin
+        for (name, prob) in Optim.UnconstrainedProblems.examples
+        	if prob.istwicedifferentiable
+        		ddf = DifferentiableFunction(prob.f, prob.g!)
+        		res = Optim.optimize(ddf, prob.initial_x, Newton(), Optim.Options(autodiff = true))
+        		@test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
+        		res = Optim.optimize(ddf.f, prob.initial_x, Newton(), Optim.Options(autodiff = true))
+        		@test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
+                res = Optim.optimize(ddf.f, ddf.g!, prob.initial_x, Newton(), Optim.Options(autodiff = true))
+        		@test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
+        	end
+        end
     end
 end

--- a/test/newton.jl
+++ b/test/newton.jl
@@ -1,4 +1,4 @@
-let
+@testset "Newton" begin
     function f_1(x::Vector)
         (x[1] - 5.0)^4
     end
@@ -19,8 +19,8 @@ let
 
     results = Optim.optimize(d, [0.0], Newton())
     @test_throws ErrorException Optim.x_trace(results)
-    @assert Optim.g_converged(results)
-    @assert norm(Optim.minimizer(results) - [5.0]) < 0.01
+    @test Optim.g_converged(results)
+    @test norm(Optim.minimizer(results) - [5.0]) < 0.01
 
     eta = 0.9
 
@@ -43,15 +43,15 @@ let
     d = TwiceDifferentiableFunction(f_2, g!_2, h!_2)
     results = Optim.optimize(d, [127.0, 921.0], Newton())
     @test_throws ErrorException Optim.x_trace(results)
-    @assert Optim.g_converged(results)
-    @assert norm(Optim.minimizer(results) - [0.0, 0.0]) < 0.01
+    @test Optim.g_converged(results)
+    @test norm(Optim.minimizer(results) - [0.0, 0.0]) < 0.01
 
     # Test Optim.newton for all twice differentiable functions in Optim.UnconstrainedProblems.examples
     for (name, prob) in Optim.UnconstrainedProblems.examples
     	if prob.istwicedifferentiable
     		ddf = TwiceDifferentiableFunction(prob.f, prob.g!,prob.h!)
     		res = Optim.optimize(ddf, prob.initial_x, Newton())
-    		@assert norm(Optim.minimizer(res) - prob.solutions) < 1e-2
+    		@test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
     	end
     end
 
@@ -59,7 +59,7 @@ let
         prob=Optim.UnconstrainedProblems.examples["Himmelblau"]
         ddf = TwiceDifferentiableFunction(prob.f, prob.g!, prob.h!)
         res = optimize(ddf, [0., 0.], Newton())
-        @assert norm(Optim.minimizer(res) - prob.solutions) < 1e-10
+        @test norm(Optim.minimizer(res) - prob.solutions) < 1e-10
     end
 
 
@@ -67,11 +67,11 @@ let
     	if prob.istwicedifferentiable
     		ddf = DifferentiableFunction(prob.f, prob.g!)
     		res = Optim.optimize(ddf, prob.initial_x, Newton(), Optim.Options(autodiff = true))
-    		@assert norm(Optim.minimizer(res) - prob.solutions) < 1e-2
+    		@test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
     		res = Optim.optimize(ddf.f, prob.initial_x, Newton(), Optim.Options(autodiff = true))
-    		@assert norm(Optim.minimizer(res) - prob.solutions) < 1e-2
+    		@test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
             res = Optim.optimize(ddf.f, ddf.g!, prob.initial_x, Newton(), Optim.Options(autodiff = true))
-    		@assert norm(Optim.minimizer(res) - prob.solutions) < 1e-2
+    		@test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
     	end
     end
 end

--- a/test/newton_trust_region.jl
+++ b/test/newton_trust_region.jl
@@ -1,4 +1,5 @@
-let
+@testset "Newton Trust Region" begin
+@testset "Subproblems I" begin
     # verify that solve_tr_subproblem! finds the minimum
     n = 2
     gr = [-0.74637,0.52388]
@@ -11,11 +12,11 @@ let
         bad_s = rand(n)
         bad_s ./= norm(bad_s)  # boundary
         model(s2) = (gr' * s2)[] + .5 * (s2' * H * s2)[]
-        @assert model(s) <= model(bad_s) + 1e-8
+        @test model(s) <= model(bad_s) + 1e-8
     end
 end
 
-let
+@testset "Subproblems II" begin
     # random Hessians--verify that solve_tr_subproblem! finds the minimum
     for i in 1:10000
         n = rand(1:10)
@@ -27,19 +28,19 @@ let
         m, interior = Optim.solve_tr_subproblem!(gr, H, 1., s, max_iters=100)
 
         model(s2) = (gr' * s2)[] + .5 * (s2' * H * s2)[]
-        @assert model(s) <= model(zeros(n)) + 1e-8  # origin
+        @test model(s) <= model(zeros(n)) + 1e-8  # origin
 
         for j in 1:10
             bad_s = rand(n)
             bad_s ./= norm(bad_s)  # boundary
-            @assert model(s) <= model(bad_s) + 1e-8
+            @test model(s) <= model(bad_s) + 1e-8
             bad_s .*= rand()  # interior
-            @assert model(s) <= model(bad_s) + 1e-8
+            @test model(s) <= model(bad_s) + 1e-8
         end
     end
 end
 
-let
+@testset "Test problems" begin
     #######################################
     # First test the subproblem.
     srand(42)
@@ -61,53 +62,53 @@ let
     delta = sqrt(s_norm2) + 1.0
     m, interior, lambda, hard_case, reached_solution =
         Optim.solve_tr_subproblem!(gr, H, delta, s)
-    @assert interior
-    @assert !hard_case
-    @assert reached_solution
-    @assert abs(m - true_m) < 1e-12
-    @assert norm(s - true_s) < 1e-12
-    @assert abs(lambda) < 1e-12
+    @test interior
+    @test !hard_case
+    @test reached_solution
+    @test abs(m - true_m) < 1e-12
+    @test norm(s - true_s) < 1e-12
+    @test abs(lambda) < 1e-12
 
     # A boundary solution
     delta = 0.5 * sqrt(s_norm2)
     m, interior, lambda, hard_case, reached_solution =
         Optim.solve_tr_subproblem!(gr, H, delta, s)
-    @assert !interior
-    @assert !hard_case
-    @assert reached_solution
-    @assert m > true_m
-    @assert abs(norm(s) - delta) < 1e-12
-    @assert lambda > 0
+    @test !interior
+    @test !hard_case
+    @test reached_solution
+    @test m > true_m
+    @test abs(norm(s) - delta) < 1e-12
+    @test lambda > 0
 
     # A "hard case" where the gradient is orthogonal to the lowest eigenvector
 
     # Test the checking
     hard_case, lambda_1_multiplicity =
         Optim.check_hard_case_candidate([-1., 2., 3.], [0., 1., 1.])
-    @assert hard_case
-    @assert lambda_1_multiplicity == 1
+    @test hard_case
+    @test lambda_1_multiplicity == 1
 
     hard_case, lambda_1_multiplicity =
         Optim.check_hard_case_candidate([-1., -1., 3.], [0., 0., 1.])
-    @assert hard_case
-    @assert lambda_1_multiplicity == 2
+    @test hard_case
+    @test lambda_1_multiplicity == 2
 
     hard_case, lambda_1_multiplicity =
         Optim.check_hard_case_candidate([-1., -1., -1.], [0., 0., 0.])
-    @assert hard_case
-    @assert lambda_1_multiplicity == 3
+    @test hard_case
+    @test lambda_1_multiplicity == 3
 
     hard_case, lambda_1_multiplicity =
         Optim.check_hard_case_candidate([1., 2., 3.], [0., 1., 1.])
-    @assert !hard_case
+    @test !hard_case
 
     hard_case, lambda_1_multiplicity =
         Optim.check_hard_case_candidate([-1., -1., -1.], [0., 0., 1.])
-    @assert !hard_case
+    @test !hard_case
 
     hard_case, lambda_1_multiplicity =
         Optim.check_hard_case_candidate([-1., 2., 3.], [1., 1., 1.])
-    @assert !hard_case
+    @test !hard_case
 
 
     # Now check an actual had case problem
@@ -115,9 +116,9 @@ let
     L[1] = -1.
     H = U * diagm(L) * U'
     H = 0.5 * (H' + H)
-    @assert issymmetric(H)
+    @test issymmetric(H)
     gr = U[:,2][:]
-    @assert abs(dot(gr, U[:,1][:])) < 1e-12
+    @test abs(dot(gr, U[:,1][:])) < 1e-12
     true_s = -H \ gr
     s_norm2 = dot(true_s, true_s)
     true_m = dot(true_s, gr) + 0.5 * dot(true_s, H * true_s)
@@ -125,11 +126,11 @@ let
     delta = 0.5 * sqrt(s_norm2)
     m, interior, lambda, hard_case, reached_solution =
         Optim.solve_tr_subproblem!(gr, H, delta, s)
-    @assert !interior
-    @assert hard_case
-    @assert reached_solution
-    @assert abs(lambda + L[1]) < 1e-4
-    @assert abs(norm(s) - delta) < 1e-12
+    @test !interior
+    @test hard_case
+    @test reached_solution
+    @test abs(lambda + L[1]) < 1e-4
+    @test abs(norm(s) - delta) < 1e-12
 
 
     #######################################
@@ -150,9 +151,9 @@ let
     d = TwiceDifferentiableFunction(f, g!, h!)
 
     results = Optim.optimize(d, [0.0], NewtonTrustRegion())
-    @assert length(results.trace) == 0
-    @assert results.g_converged
-    @assert norm(Optim.minimizer(results) - [5.0]) < 0.01
+    @test length(results.trace) == 0
+    @test results.g_converged
+    @test norm(Optim.minimizer(results) - [5.0]) < 0.01
 
     eta = 0.9
 
@@ -175,8 +176,8 @@ let
     d = TwiceDifferentiableFunction(f_2, g!_2, h!_2)
 
     results = Optim.optimize(d, Float64[127, 921], NewtonTrustRegion())
-    @assert results.g_converged
-    @assert norm(Optim.minimizer(results) - [0.0, 0.0]) < 0.01
+    @test results.g_converged
+    @test norm(Optim.minimizer(results) - [0.0, 0.0]) < 0.01
 
     # Test Optim.newton for all twice differentiable functions in
     # Optim.UnconstrainedProblems.examples
@@ -184,11 +185,12 @@ let
     	if prob.istwicedifferentiable
     		ddf = DifferentiableFunction(prob.f, prob.g!)
     		res = Optim.optimize(ddf, prob.initial_x, NewtonTrustRegion(), Optim.Options(autodiff = true))
-    		@assert norm(Optim.minimizer(res) - prob.solutions) < 1e-2
+    		@test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
     		res = Optim.optimize(ddf.f, prob.initial_x, NewtonTrustRegion(), Optim.Options(autodiff = true))
-    		@assert norm(Optim.minimizer(res) - prob.solutions) < 1e-2
+    		@test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
             res = Optim.optimize(ddf.f, ddf.g!, prob.initial_x, NewtonTrustRegion(), Optim.Options(autodiff = true))
-    		@assert norm(Optim.minimizer(res) - prob.solutions) < 1e-2
+    		@test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
     	end
     end
+end
 end

--- a/test/optimize.jl
+++ b/test/optimize.jl
@@ -1,4 +1,4 @@
-let
+@testset "optimize" begin
     eta = 0.9
 
     function f1(x)
@@ -18,40 +18,40 @@ let
     end
 
     results = optimize(f1, g1, h1, [127.0, 921.0])
-    @assert Optim.g_converged(results)
-    @assert norm(Optim.minimizer(results) - [0.0, 0.0]) < 0.01
+    @test Optim.g_converged(results)
+    @test norm(Optim.minimizer(results) - [0.0, 0.0]) < 0.01
 
     results = optimize(f1, g1, [127.0, 921.0])
-    @assert Optim.g_converged(results)
-    @assert norm(Optim.minimizer(results) - [0.0, 0.0]) < 0.01
+    @test Optim.g_converged(results)
+    @test norm(Optim.minimizer(results) - [0.0, 0.0]) < 0.01
 
     results = optimize(f1, [127.0, 921.0])
-    @assert Optim.g_converged(results)
-    @assert norm(Optim.minimizer(results) - [0.0, 0.0]) < 0.01
+    @test Optim.g_converged(results)
+    @test norm(Optim.minimizer(results) - [0.0, 0.0]) < 0.01
 
     results = optimize(f1, [127.0, 921.0], Optim.Options(autodiff = true))
-    @assert Optim.g_converged(results)
-    @assert norm(Optim.minimizer(results) - [0.0, 0.0]) < 0.01
+    @test Optim.g_converged(results)
+    @test norm(Optim.minimizer(results) - [0.0, 0.0]) < 0.01
 
     # tests for bfgs_initial_invH
     initial_invH = zeros(2,2)
     h1([127.0, 921.0],initial_invH)
     initial_invH = diagm(diag(initial_invH))
     results = optimize(DifferentiableFunction(f1, g1), [127.0, 921.0], BFGS(initial_invH = x -> initial_invH), Optim.Options())
-    @assert Optim.g_converged(results)
-    @assert norm(Optim.minimizer(results) - [0.0, 0.0]) < 0.01
+    @test Optim.g_converged(results)
+    @test norm(Optim.minimizer(results) - [0.0, 0.0]) < 0.01
 
     # Tests for PR #302
     results = optimize(cos, 0, 2pi);
-    @assert norm(Optim.minimizer(results) - pi) < 0.01
+    @test norm(Optim.minimizer(results) - pi) < 0.01
     results = optimize(cos, 0.0, 2pi);
-    @assert norm(Optim.minimizer(results) - pi) < 0.01
+    @test norm(Optim.minimizer(results) - pi) < 0.01
     results = optimize(cos, 0, 2pi, Brent());
-    @assert norm(Optim.minimizer(results) - pi) < 0.01
+    @test norm(Optim.minimizer(results) - pi) < 0.01
     results = optimize(cos, 0.0, 2pi, Brent());
-    @assert norm(Optim.minimizer(results) - pi) < 0.01
+    @test norm(Optim.minimizer(results) - pi) < 0.01
     results = optimize(cos, 0, 2pi, method = Brent());
-    @assert norm(Optim.minimizer(results) - pi) < 0.01
+    @test norm(Optim.minimizer(results) - pi) < 0.01
     results = optimize(cos, 0.0, 2pi, method = Brent());
-    @assert norm(Optim.minimizer(results) - pi) < 0.01
+    @test norm(Optim.minimizer(results) - pi) < 0.01
 end

--- a/test/particle_swarm.jl
+++ b/test/particle_swarm.jl
@@ -1,4 +1,4 @@
-let
+@testset "Particle Swarm" begin
     srand(100)
 
     function f_s(x::Vector)
@@ -16,7 +16,7 @@ let
     options = Optim.Options(iterations=100)
     res = Optim.optimize(f_s, initial_x, ParticleSwarm(lower, upper, n_particles),
                          options)
-    @assert norm(Optim.minimizer(res) - [5.0]) < 0.1
+    @test norm(Optim.minimizer(res) - [5.0]) < 0.1
 
     initial_x = [0.0, 0.0]
     lower = [-20., -20.]
@@ -25,7 +25,7 @@ let
     options = Optim.Options(iterations=300)
     res = Optim.optimize(rosenbrock_s, initial_x, ParticleSwarm(lower, upper, n_particles),
                              options)
-    @assert norm(Optim.minimizer(res) - [1.0, 1.0]) < 0.1
+    @test norm(Optim.minimizer(res) - [1.0, 1.0]) < 0.1
 
     # Add UnconstrainedProblems here; currently they take too many iterations to be
     # feasible

--- a/test/precon.jl
+++ b/test/precon.jl
@@ -8,7 +8,7 @@
 #     equivalent (in the limit h → 0) to that induced by the hessian, but
 #     does not approximate the hessian explicitly.
 
-let
+@testset "Preconditioning" begin
     plap(U; n=length(U)) = (n-1) * sum( (0.1 + diff(U).^2).^2 ) - sum(U) / (n-1)
     plap1(U; n=length(U), dU = diff(U), dW = 4 * (0.1 + dU.^2) .* dU) =
                             (n-1) * ([0.0; dW] - [dW; 0.0]) - ones(U) / (n-1)
@@ -20,9 +20,9 @@ let
 
     GRTOL = 1e-6
 
-    println("Test a basic preconditioning example")
+    debug_printing && println("Test a basic preconditioning example")
     for N in (10, 50, 250)
-        println("N = ", N)
+        debug_printing && println("N = ", N)
         initial_x = zeros(N)
         Plap = precond(initial_x)
         ID = nothing
@@ -32,13 +32,13 @@ let
                                          optimizer(P = P),
                                          Optim.Options(f_tol = 1e-32,
                                                              g_tol = GRTOL))
-                println(optimizer, wwo,
-                        " preconditioning : g_calls = ", results.g_calls,
-                        ", f_calls = ", results.f_calls)
+                debug_printing && println(optimizer, wwo,
+                                          " preconditioning : g_calls = ", Optim.g_calls(results),
+                                          ", f_calls = ", Optim.f_calls(results))
                 if (optimizer == GradientDescent) && (N > 15) && (P == ID)
-                    println("    (gradient descent is not expected to converge)")
+                    debug_printing && println("    (gradient descent is not expected to converge)")
                 else
-                    @assert Optim.converged(results)
+                    @test Optim.converged(results)
                 end
             end
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,21 +1,15 @@
-#
-# Correctness Tests
-#
+using Optim, Base.Test, Compat
 
-using Optim
-using Base.Test
-using Compat
+debug_printing = false
 
 my_tests = [
     "types.jl",
-    "lsthrow.jl",
     "bfgs.jl",
     "gradient_descent.jl",
     "accelerated_gradient_descent.jl",
     "momentum_gradient_descent.jl",
     "grid_search.jl",
     "l_bfgs.jl",
-    "levenberg_marquardt.jl",
     "newton.jl",
     "newton_trust_region.jl",
     "cg.jl",
@@ -23,7 +17,6 @@ my_tests = [
     "optimize.jl",
     "simulated_annealing.jl",
     "particle_swarm.jl",
-    "api.jl",
     "golden_section.jl",
     "brent.jl",
     "type_stability.jl",
@@ -32,12 +25,12 @@ my_tests = [
     "callbacks.jl",
     "precon.jl",
     "initial_convergence.jl",
-    "extrapolate.jl"
+    "extrapolate.jl",
+    "levenberg_marquardt.jl",
+    "lsthrow.jl",
+    "api.jl",
 ]
 
-println("Running tests:")
-
 for my_test in my_tests
-    println(" * $(my_test)")
     include(my_test)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,10 @@
-using Optim, Base.Test, Compat
-
+using Optim, Compat
+if VERSION >= v"0.5-"
+    using Base.Test
+else
+    using BaseTestNext
+    const Test = BaseTestNext
+end
 debug_printing = false
 
 my_tests = [

--- a/test/simulated_annealing.jl
+++ b/test/simulated_annealing.jl
@@ -1,4 +1,4 @@
-let
+@testset "Simulated Annealing" begin
     srand(1)
 
     function f_s(x::Vector)
@@ -6,12 +6,12 @@ let
     end
     options = Optim.Options(iterations=100_000)
     results = Optim.optimize(f_s, [0.0], SimulatedAnnealing(), options)
-    @assert norm(Optim.minimizer(results) - [5.0]) < 0.1
+    @test norm(Optim.minimizer(results) - [5.0]) < 0.1
 
     function rosenbrock_s(x::Vector)
         (1.0 - x[1])^2 + 100.0 * (x[2] - x[1]^2)^2
     end
     options = Optim.Options(iterations=100_000)
     results = Optim.optimize(rosenbrock_s, [0.0, 0.0], SimulatedAnnealing(), options)
-    @assert norm(Optim.minimizer(results) - [1.0, 1.0]) < 0.1
+    @test norm(Optim.minimizer(results) - [1.0, 1.0]) < 0.1
 end

--- a/test/type_stability.jl
+++ b/test/type_stability.jl
@@ -1,4 +1,4 @@
-let
+@testset "Type Stability" begin
     function rosenbrock{T}(x::Vector{T})
         o = one(T)
         c = convert(T,100)

--- a/test/type_stability.jl
+++ b/test/type_stability.jl
@@ -28,23 +28,18 @@
                                      rosenbrock_gradient!,
                                      rosenbrock_hessian!)
 
-    for method in (NelderMead(), SimulatedAnnealing())
-        optimize(rosenbrock, [0.0,0,.0], method)
-        optimize(rosenbrock, Float32[0.0, 0.0], method)
-    end
-
-    for method in (BFGS(),
+    for method in (NelderMead(),
+                   SimulatedAnnealing(),
+                   BFGS(),
                    ConjugateGradient(),
                    GradientDescent(),
                    MomentumGradientDescent(),
                    AcceleratedGradientDescent(),
-                   LBFGS())
-        optimize(d2, [0.0,0,.0], method)
-        optimize(d2, Float32[0.0, 0.0], method)
-    end
-
-    for method in (Newton(),)# NewtonTrustRegion())
-        optimize(d3, [0.0,0.0], method)
-        optimize(d3, Float32[0.0, 0.0], method)
+                   LBFGS(),
+                   Newton())
+        for T in (Float32, Float64)
+            result = optimize(d3, fill(zero(T), 2), method)
+            @test eltype(Optim.minimizer(result)) == T
+        end
     end
 end

--- a/test/types.jl
+++ b/test/types.jl
@@ -1,7 +1,7 @@
 using Compat
 import Compat.String
 
-let
+@testset "Types" begin
     solver = NelderMead()
     T = typeof(solver)
     trace = OptimizationTrace{T}()


### PR DESCRIPTION
Just something I've been wanting to do for some time. I think we should also move all the identical loops over problems into the `optimize` test set, and let individual files for each solver be there only if we have unit tests for related methods or very specific problems. NewtonTrustRegion is a perfect example with tests for the subproblem solver.