### PR TITLE
bug fix for newton_trust_region

### DIFF
--- a/src/newton_trust_region.jl
+++ b/src/newton_trust_region.jl
@@ -124,8 +124,9 @@ function solve_tr_subproblem!{T}(gr::Vector{T},
             p_lambda2 = p_sq_norm(lambda, min_H_ev_multiplicity + 1)
             if p_lambda2 > delta_sq
                 # Then we can simply solve using root finding.
-                # Set a starting point between the minimum and largest eigenvalues.
-                lambda = lambda_lb + 0.01 * (max_H_ev - lambda_lb)
+                # Set a starting point greater than the minimum based on the
+                # range between the largest and smallest eigenvalues.
+                lambda = lambda_lb + 0.01 * (max_H_ev - min_H_ev)
             else
                 hard_case = true
                 reached_solution = true

--- a/test/newton_trust_region.jl
+++ b/test/newton_trust_region.jl
@@ -193,4 +193,11 @@ end
     	end
     end
 end
+
+
+@testset "PR #341" begin
+    # verify that no PosDef exception is thrown
+    Optim.solve_tr_subproblem!([0, 1.], [-1000 0; 0. -999], 1e-2, ones(2))
+end
+
 end


### PR DESCRIPTION
This PR fixes a bug in `newton_trust_region.jl`. In the loop around line 128, we want to increment lambda by 1% of the **difference** between the largest and smallest eigenvalues. Without this PR, we're effectively incrementing lambda by 1% of the **sum** of the largest and smallest eigenvalues.   That can lead to a `Base.LinAlg.PosDefException(5)` later in the code if the algebraically smallest eigenvalue is larger in magnitude than the algebraically largest eigenvalue, as reported by @rgiordan in jeff-regier/Celeste.jl#529
