### PR TITLE
Reintroduce generic Array inputs.

### DIFF
--- a/docs/src/dev/contributing.md
+++ b/docs/src/dev/contributing.md
@@ -29,12 +29,12 @@ end
 Minim(; linesearch = LineSearches.hagerzhang!, minim_parameter = 1.0) =
   Minim(linesearch, minim_parameter)
 
-type MinimState{T}
+type MinimState{T,N,G}
   @add_generic_fields()
-  x_previous::Array{T}
-  g::Array{T}
+  x_previous::Array{T,N}
+  g::G
   f_x_previous::T
-  s::Array{T}
+  s::Array{T,N}
   @add_linesearch_fields()
 end
 

--- a/docs/src/user/minimization.md
+++ b/docs/src/user/minimization.md
@@ -170,6 +170,9 @@ Defined for multivariate optimization:
 * `g_converged(res)`
 * `initial_state(res)`
 
+## Input types
+Most users will input `Vector`'s as their `initial_x`'s, and get an `Optim.minimizer(res)` out that is also a vector. For zeroth and first order methods, it is also possible to pass in matrices, or even higher dimensional arrays. The only restriction imposed by leaving the `Vector` case is, that it is no longer possible to use finite difference approximations or autmatic differentiation. Second order methods (variants of Newton's method) do not support this more general input type.
+
 ## Notes on convergence flags and checks
 Currently, it is possible to access a minimizer using `Optim.minimizer(result)` even if
 all convergence flags are `false`. This means that the user has to be a bit careful when using

--- a/src/accelerated_gradient_descent.jl
+++ b/src/accelerated_gradient_descent.jl
@@ -20,15 +20,15 @@ function AcceleratedGradientDescent(; linesearch! = nothing,
     AcceleratedGradientDescent(linesearch)
 end
 
-type AcceleratedGradientDescentState{T}
+type AcceleratedGradientDescentState{T,N,G}
     @add_generic_fields()
-    x_previous::Array{T}
-    g::Array{T}
+    x_previous::Array{T,N}
+    g::G
     f_x_previous::T
     iteration::Int
-    y::Array{T}
-    y_previous::Array{T}
-    s::Array{T}
+    y::Array{T,N}
+    y_previous::Array{T,N}
+    s::Array{T,N}
     @add_linesearch_fields()
 end
 

--- a/src/accelerated_gradient_descent.jl
+++ b/src/accelerated_gradient_descent.jl
@@ -43,12 +43,12 @@ function initial_state{T}(method::AcceleratedGradientDescent, options, d, initia
                          1, # Track f calls in state.f_calls
                          1, # Track g calls in state.g_calls
                          0, # Track h calls in state.h_calls
-                         copy(initial_x), # Maintain current state in state.x_previous
+                         copy(initial_x), # Maintain previous state in state.x_previous
                          g, # Store current gradient in state.g
                          T(NaN), # Store previous f in state.f_x_previous
                          0, # Iteration
-                         copy(initial_x), # Maintain intermediary current state in state.y
-                         copy(initial_x), # Maintain intermediary state in state.y_previous
+                         similar(initial_x), # Maintain intermediary current state in state.y
+                         similar(initial_x), # Maintain intermediary state in state.y_previous
                          similar(initial_x), # Maintain current search direction in state.s
                          @initial_linesearch()...) # Maintain a cache for line search results in state.lsr
 end
@@ -63,14 +63,14 @@ function update_state!{T}(d, state::AcceleratedGradientDescentState{T}, method::
     # Determine the distance of movement along the search line
     lssuccess = perform_linesearch!(state, method, d)
 
+    # Record previous state
+    copy!(state.x_previous, state.x)
+
     # Make one move in the direction of the gradient
     copy!(state.y_previous, state.y)
     @simd for i in 1:state.n
-        @inbounds state.y[i] = state.x_previous[i] + state.alpha * state.s[i]
+        @inbounds state.y[i] = state.x[i] + state.alpha * state.s[i]
     end
-
-    # Record previous state
-    copy!(state.x_previous, state.x)
 
     # Update current position with Nesterov correction
     scaling = (state.iteration - 1) / (state.iteration + 2)
@@ -82,5 +82,5 @@ function update_state!{T}(d, state::AcceleratedGradientDescentState{T}, method::
     state.f_x_previous, state.f_x = state.f_x, d.fg!(state.x, state.g)
     state.f_calls, state.g_calls = state.f_calls + 1, state.g_calls + 1
 
-    (lssuccess == false) # break on linesearch error
+    lssuccess == false # break on linesearch error
 end

--- a/src/bfgs.jl
+++ b/src/bfgs.jl
@@ -18,17 +18,17 @@ function BFGS(; linesearch! = nothing,
     BFGS(linesearch, initial_invH, resetalpha)
 end
 
-type BFGSState{T}
+type BFGSState{T,N,G}
     @add_generic_fields()
-    x_previous::Array{T}
-    g::Array{T}
-    g_previous::Array{T}
+    x_previous::Array{T,N}
+    g::G
+    g_previous::G
     f_x_previous::T
-    dx::Array{T}
-    dg::Array{T}
-    u::Array{T}
-    invH::Array{T}
-    s::Array{T}
+    dx::Array{T,N}
+    dg::Array{T,N}
+    u::Array{T,N}
+    invH::Matrix{T}
+    s::Array{T,N}
     @add_linesearch_fields()
 end
 
@@ -49,11 +49,11 @@ function initial_state{T}(method::BFGS, options, d, initial_x::Array{T})
               g, # Store current gradient in state.g
               copy(g), # Store previous gradient in state.g_previous
               T(NaN), # Store previous f in state.f_x_previous
-              Array{T}(n), # Store changes in position in state.dx
-              Array{T}(n), # Store changes in gradient in state.dg
-              Array{T}(n), # Buffer stored in state.u
+              similar(initial_x), # Store changes in position in state.dx
+              similar(initial_x), # Store changes in gradient in state.dg
+              similar(initial_x), # Buffer stored in state.u
               method.initial_invH(initial_x), # Store current invH in state.invH
-              Array{T}(n), # Store current search direction in state.s
+              similar(initial_x), # Store current search direction in state.s
               @initial_linesearch()...) # Maintain a cache for line search results in state.lsr
 end
 

--- a/src/bfgs.jl
+++ b/src/bfgs.jl
@@ -45,7 +45,7 @@ function initial_state{T}(method::BFGS, options, d, initial_x::Array{T})
               1, # Track f calls in state.f_calls
               1, # Track g calls in state.g_calls
               0, # Track h calls in state.h_calls
-              copy(initial_x), # Maintain current state in state.x_previous
+              similar(initial_x), # Maintain previous state in state.x_previous
               g, # Store current gradient in state.g
               copy(g), # Store previous gradient in state.g_previous
               T(NaN), # Store previous f in state.f_x_previous
@@ -80,7 +80,7 @@ function update_state!{T}(d, state::BFGSState{T}, method::BFGS)
 
     # Maintain a record of the previous gradient
     copy!(state.g_previous, state.g)
-    (lssuccess == false) # break on linesearch error
+    lssuccess == false # break on linesearch error
 end
 
 function update_h!(d, state, mehtod::BFGS)

--- a/src/cg.jl
+++ b/src/cg.jl
@@ -126,14 +126,14 @@ function initial_state{T}(method::ConjugateGradient, options, d, initial_x::Arra
                          1, # Track f calls in state.f_calls
                          1, # Track g calls in state.g_calls
                          0, # Track h calls in state.h_calls
-                         copy(initial_x), # Maintain current state in state.x_previous
+                         similar(initial_x), # Maintain previous state in state.x_previous
                          g, # Store current gradient in state.g
-                         copy(g), # Store previous gradient in state.g_previous
+                         similar(g), # Store previous gradient in state.g_previous
                          T(NaN), # Store previous f in state.f_x_previous
                          similar(initial_x), # Intermediate value in CG calculation
                          similar(initial_x), # Preconditioned intermediate value in CG calculation
                          pg, # Maintain the preconditioned gradient in pg
-                         -copy(pg), # Maintain current search direction in state.s
+                         -pg, # Maintain current search direction in state.s
                          @initial_linesearch()...) # Maintain a cache for line search results in state.lsr
 end
 

--- a/src/cg.jl
+++ b/src/cg.jl
@@ -84,16 +84,16 @@ function ConjugateGradient(; linesearch! = nothing,
                       linesearch)
 end
 
-type ConjugateGradientState{T}
+type ConjugateGradientState{T,N,G}
     @add_generic_fields()
-    x_previous::Array{T}
-    g::Array{T}
-    g_previous::Array{T}
+    x_previous::Array{T,N}
+    g::G
+    g_previous::G
     f_x_previous::T
-    y::Array{T}
-    py::Array{T}
-    pg::Array{T}
-    s::Array{T}
+    y::Array{T,N}
+    py::Array{T,N}
+    pg::Array{T,N}
+    s::Array{T,N}
     @add_linesearch_fields()
 end
 

--- a/src/gradient_descent.jl
+++ b/src/gradient_descent.jl
@@ -19,12 +19,12 @@ function GradientDescent(; linesearch! = nothing,
     GradientDescent(linesearch, P, precondprep)
 end
 
-type GradientDescentState{T}
+type GradientDescentState{T,N,G}
     @add_generic_fields()
-    x_previous::Array{T}
-    g::Array{T}
+    x_previous::Array{T,N}
+    g::G
     f_x_previous::T
-    s::Array{T}
+    s::Array{T,N}
     @add_linesearch_fields()
 end
 

--- a/src/gradient_descent.jl
+++ b/src/gradient_descent.jl
@@ -39,7 +39,7 @@ function initial_state{T}(method::GradientDescent, options, d, initial_x::Array{
                          1, # Track f calls in state.f_calls
                          1, # Track g calls in state.g_calls
                          0, # Track h calls in state.h_calls
-                         copy(initial_x), # Maintain current state in state.x_previous
+                         similar(initial_x), # Maintain previous state in state.x_previous
                          g, # Store current gradient in state.g
                          T(NaN), # Store previous f in state.f_x_previous
                          similar(initial_x), # Maintain current search direction in state.s

--- a/src/l_bfgs.jl
+++ b/src/l_bfgs.jl
@@ -121,9 +121,9 @@ function initial_state{T}(method::LBFGS, options, d, initial_x::Array{T})
               1, # Track f calls in state.f_calls
               1, # Track g calls in state.g_calls
               0, # Track h calls in state.h_calls
-              copy(initial_x), # Maintain current state in state.x_previous
+              similar(initial_x), # Maintain previous state in state.x_previous
               g, # Store current gradient in state.g
-              copy(g), # Store previous gradient in state.g_previous
+              similar(g), # Store previous gradient in state.g_previous
               Array{T}(method.m), # state.rho
               Array{T}(n, method.m), # Store changes in position in state.dx_history
               Array{T}(n, method.m), # Store changes in gradient in state.dg_history

--- a/src/l_bfgs.jl
+++ b/src/l_bfgs.jl
@@ -89,22 +89,22 @@ function LBFGS(; linesearch! = nothing,
     LBFGS(Int(m), linesearch, P, precondprep, extrapolate, snap2one)
 end
 
-type LBFGSState{T}
+type LBFGSState{T,N,M}
     @add_generic_fields()
-    x_previous::Array{T}
-    g::Array{T}
-    g_previous::Array{T}
-    rho::Array{T}
-    dx_history::Array{T}
-    dg_history::Array{T}
-    dx::Array{T}
-    dg::Array{T}
-    u::Array{T}
+    x_previous::Array{T,N}
+    g::Array{T,N}
+    g_previous::Array{T,N}
+    rho::Array{T,N}
+    dx_history::Array{T,M}
+    dg_history::Array{T,M}
+    dx::Array{T,N}
+    dg::Array{T,N}
+    u::Array{T,N}
     f_x_previous::T
     twoloop_q
     twoloop_alpha
     pseudo_iteration::Int
-    s::Array{T}
+    s::Array{T,N}
     @add_linesearch_fields()
 end
 
@@ -127,14 +127,14 @@ function initial_state{T}(method::LBFGS, options, d, initial_x::Array{T})
               Array{T}(method.m), # state.rho
               Array{T}(n, method.m), # Store changes in position in state.dx_history
               Array{T}(n, method.m), # Store changes in gradient in state.dg_history
-              Array{T}(n), # Buffer for new entry in state.dx_history
-              Array{T}(n), # Buffer for new entry in state.dg_history
-              Array{T}(n), # Buffer stored in state.u
+              similar(initial_x), # Buffer for new entry in state.dx_history
+              similar(initial_x), # Buffer for new entry in state.dg_history
+              similar(initial_x), # Buffer stored in state.u
               T(NaN), # Store previous f in state.f_x_previous
-              Array{T}(n), #Buffer for use by twoloop
+              similar(initial_x), #Buffer for use by twoloop
               Array{T}(method.m), #Buffer for use by twoloop
               0,
-              Array{T}(n), # Store current search direction in state.s
+              similar(initial_x), # Store current search direction in state.s
               @initial_linesearch()...) # Maintain a cache for line search results in state.lsr
 end
 

--- a/src/momentum_gradient_descent.jl
+++ b/src/momentum_gradient_descent.jl
@@ -17,12 +17,12 @@ function MomentumGradientDescent(; mu::Real = 0.01, linesearch! = nothing,
     MomentumGradientDescent(Float64(mu), linesearch)
 end
 
-type MomentumGradientDescentState{T}
+type MomentumGradientDescentState{T,N,G}
     @add_generic_fields()
-    x_previous::Array{T}
-    g::Array{T}
+    x_previous::Array{T,N}
+    g::G
     f_x_previous::T
-    s::Array{T}
+    s::Array{T,N}
     @add_linesearch_fields()
 end
 

--- a/src/momentum_gradient_descent.jl
+++ b/src/momentum_gradient_descent.jl
@@ -37,7 +37,7 @@ function initial_state{T}(method::MomentumGradientDescent, options, d, initial_x
                          1, # Track f calls in state.f_calls
                          1, # Track g calls in state.g_calls
                          0, # Track h calls in state.h_calls
-                         copy(initial_x), # Maintain current state in state.x_previous
+                         copy(initial_x), # Maintain previous state in state.x_previous
                          g, # Store current gradient in state.g
                          T(NaN), # Store previous f in state.f_x_previous
                          similar(initial_x), # Maintain current search direction in state.s

--- a/src/nelder_mead.jl
+++ b/src/nelder_mead.jl
@@ -6,7 +6,7 @@ immutable AffineSimplexer <: Simplexer
 end
 AffineSimplexer(;a = 0.025, b = 0.5) = AffineSimplexer(a, b)
 
-function simplexer{T, N}(S::AffineSimplexer, initial_x::Array{T, N})
+function simplexer{T,N}(S::AffineSimplexer, initial_x::Array{T,N})
     n = length(initial_x)
     initial_simplex = Array{T, N}[copy(initial_x) for i = 1:n+1]
     for j = 1:n
@@ -107,13 +107,13 @@ type NelderMeadState{T, N}
     @add_generic_fields()
     m::Int
     simplex::Vector{Array{T,N}}
-    x_centroid::Array{T}
-    x_lowest::Array{T}
-    x_second_highest::Array{T}
-    x_highest::Array{T}
-    x_reflect::Array{T}
-    x_cache::Array{T}
-    f_simplex::Array{T}
+    x_centroid::Array{T,N}
+    x_lowest::Array{T,N}
+    x_second_highest::Array{T,N}
+    x_highest::Array{T,N}
+    x_reflect::Array{T,N}
+    x_cache::Array{T,N}
+    f_simplex::Array{T,N}
     nm_x::T
     f_lowest::T
     i_order::Vector{Int}
@@ -143,7 +143,7 @@ function initial_state{F<:Function, T}(method::NelderMead, options, f::F, initia
 
 NelderMeadState("Nelder-Mead",
           n, # Dimensionality of the problem
-          Array{T}(n), # Variable to hold final minimizer value for MultivariateOptimizationResults
+          similar(initial_x), # Variable to hold final minimizer value for MultivariateOptimizationResults
           f_simplex[i_order[1]], # Store Nelder Mead objective in state.f_x = state.f_lowest
           m,
           0,
@@ -151,11 +151,11 @@ NelderMeadState("Nelder-Mead",
           m, # Number of vertices in the simplex
           simplex, # Maintain simplex in state.simplex
           centroid(simplex,  i_order[m]), # Maintain centroid in state.centroid
-          Array{T}(n), # Store cache in state.x_lowest
-          Array{T}(n), # Store cache in state.x_second_highest
-          Array{T}(n), # Store cache in state.x_highest
-          Array{T}(n), # Store cache in state.x_reflect
-          Array{T}(n), # Store cache in state.x_cache
+          similar(initial_x), # Store cache in state.x_lowest
+          similar(initial_x), # Store cache in state.x_second_highest
+          similar(initial_x), # Store cache in state.x_highest
+          similar(initial_x), # Store cache in state.x_reflect
+          similar(initial_x), # Store cache in state.x_cache
           f_simplex, # Store objective values at the vertices in state.f_simplex
           T(nmobjective(f_simplex, n, m)), # Store nmobjective in state.nm_x
           f_simplex[i_order[1]], # Store lowest f in state.f_lowest

--- a/src/newton.jl
+++ b/src/newton.jl
@@ -12,15 +12,15 @@ function Newton(; linesearch! = nothing, linesearch::Function = LineSearches.hag
     Newton(linesearch,resetalpha)
 end
 
-type NewtonState{T}
+type NewtonState{T, N, F<:Base.LinAlg.Cholesky, Thd}
     @add_generic_fields()
-    x_previous::Array{T}
-    g::Array{T}
+    x_previous::Array{T, N}
+    g::Array{T, N}
     f_x_previous::T
-    H
-    F
-    Hd
-    s::Array{T}
+    H::Matrix{T}
+    F::F
+    Hd::Thd
+    s::Array{T, N}
     @add_linesearch_fields()
 end
 
@@ -47,8 +47,8 @@ function initial_state{T}(method::Newton, options, d, initial_x::Array{T})
                 g, # Store current gradient in state.g
                 T(NaN), # Store previous f in state.f_x_previous
                 H,
-                copy(H),
-                copy(H),
+                Base.LinAlg.Cholesky(Matrix{T}(), :U),
+                Vector{Int8}(),
                 similar(initial_x), # Maintain current search direction in state.s
                 @initial_linesearch()...) # Maintain a cache for line search results in state.lsr
 end

--- a/src/newton.jl
+++ b/src/newton.jl
@@ -43,7 +43,7 @@ function initial_state{T}(method::Newton, options, d, initial_x::Array{T})
                 f_calls, # Track f calls in state.f_calls
                 g_calls, # Track g calls in state.g_calls
                 h_calls,
-                copy(initial_x), # Maintain current state in state.x_previous
+                similar(initial_x), # Maintain previous state in state.x_previous
                 g, # Store current gradient in state.g
                 T(NaN), # Store previous f in state.f_x_previous
                 H,

--- a/src/newton_trust_region.jl
+++ b/src/newton_trust_region.jl
@@ -253,9 +253,9 @@ function initial_state{T}(method::NewtonTrustRegion, options, d, initial_x::Arra
                          f_calls, # Track f calls in state.f_calls
                          g_calls, # Track g calls in state.g_calls
                          h_calls,
-                         copy(initial_x), # Maintain current state in state.x_previous
+                         similar(initial_x), # Maintain previous state in state.x_previous
                          g, # Store current gradient in state.g
-                         copy(g), # Store previous gradient in state.g_previous
+                         similar(g), # Store previous gradient in state.g_previous
                          T(NaN), # Store previous f in state.f_x_previous
                          similar(initial_x), # Maintain current search direction in state.s
                          H,

--- a/src/newton_trust_region.jl
+++ b/src/newton_trust_region.jl
@@ -205,13 +205,13 @@ NewtonTrustRegion(; initial_delta::Real = 1.0,
                     NewtonTrustRegion(initial_delta, delta_hat, eta, rho_lower, rho_upper)
 
 
-type NewtonTrustRegionState{T}
+type NewtonTrustRegionState{T,N,G}
     @add_generic_fields()
-    x_previous::Array{T}
-    g::Array{T}
-    g_previous::Array{T}
+    x_previous::Array{T,N}
+    g::G
+    g_previous::G
     f_x_previous::T
-    s::Array{T}
+    s::Array{T,N}
     H
     hard_case
     reached_subproblem_solution

--- a/src/particle_swarm.jl
+++ b/src/particle_swarm.jl
@@ -6,11 +6,11 @@ end
 
 ParticleSwarm(; lower = [], upper = [], n_particles = 0) = ParticleSwarm(lower, upper, n_particles)
 
-type ParticleSwarmState{T}
+type ParticleSwarmState{T,N}
     @add_generic_fields()
     iteration::Int
-    lower
-    upper
+    lower::Array{T,N}
+    upper::Array{T,N}
     c1::T # Weight variable; currently not exposed to users
     c2::T # Weight variable; currently not exposed to users
     w::T  # Weight variable; currently not exposed to users
@@ -19,11 +19,11 @@ type ParticleSwarmState{T}
     X
     V
     X_best
-    score
-    best_score
+    score::Array{T,N}
+    best_score::Array{T,N}
     x_learn
     current_state
-    iterations
+    iterations::Int
 end
 
 initial_state(method::ParticleSwarm, options, d, initial_x::Array) = initial_state(method, options, d.f, initial_x)

--- a/src/simulated_annealing.jl
+++ b/src/simulated_annealing.jl
@@ -44,7 +44,7 @@ function initial_state{T}(method::SimulatedAnnealing, options, f::Function, init
     # Store the best state ever visited
     best_x = copy(initial_x)
     best_f_x = f_x
-    SimulatedAnnealingState("Simulated Annealing", n, copy(initial_x), f_x, f_calls, 0, 0, 1, similar(initial_x), best_x, best_f_x, f_x)
+    SimulatedAnnealingState("Simulated Annealing", n, copy(best_x), f_x, f_calls, 0, 0, 1, best_x, similar(initial_x), best_f_x, f_x)
 end
 
 update_state!(d, state::SimulatedAnnealingState, method::SimulatedAnnealing) = update_state!(d.f, state, method)

--- a/src/simulated_annealing.jl
+++ b/src/simulated_annealing.jl
@@ -44,7 +44,7 @@ function initial_state{T}(method::SimulatedAnnealing, options, f::Function, init
     # Store the best state ever visited
     best_x = copy(initial_x)
     best_f_x = f_x
-    SimulatedAnnealingState("Simulated Annealing", n, copy(initial_x), f_x, f_calls, 0, 0, 1, copy(initial_x), best_x, best_f_x, f_x)
+    SimulatedAnnealingState("Simulated Annealing", n, copy(initial_x), f_x, f_calls, 0, 0, 1, similar(initial_x), best_x, best_f_x, f_x)
 end
 
 update_state!(d, state::SimulatedAnnealingState, method::SimulatedAnnealing) = update_state!(d.f, state, method)

--- a/src/utilities/generic.jl
+++ b/src/utilities/generic.jl
@@ -10,7 +10,7 @@ end
 @def add_generic_fields begin
     method_string::String
     n::Int
-    x::Array{T}
+    x::Array{T,N}
     f_x::T
     f_calls::Int
     g_calls::Int
@@ -18,8 +18,8 @@ end
 end
 
 @def add_linesearch_fields begin
-    x_ls::Array{T}
-    g_ls::Array{T}
+    x_ls::Array{T,N}
+    g_ls::Array{T,N}
     alpha::T
     mayterminate::Bool
     lsr::LineSearches.LineSearchResults

--- a/test/array.jl
+++ b/test/array.jl
@@ -1,18 +1,46 @@
-@testset "Matrix input" begin
-    f(X) = (10 - X[1, 1])^2 + (0 - X[1, 2])^2 + (0 - X[2, 1])^2 + (5 - X[2, 2])^2
+@testset "input types" begin
+    f(X) = (10 - X[1])^2 + (0 - X[2])^2 + (0 - X[3])^2 + (5 - X[4])^2
 
     function g!(X, S)
-        S[1, 1] = -20 + 2 * X[1, 1]
-        S[1, 2] = 2 * X[1, 2]
-        S[2, 1] = 2 * X[2, 1]
-        S[2, 2] = -10 + 2 * X[2, 2]
+        S[1] = -20 + 2 * X[1]
+        S[2] = 2 * X[2]
+        S[3] = 2 * X[3]
+        S[4] = -10 + 2 * X[4]
         return
     end
+    @testset "vector" begin
+        for m in (AcceleratedGradientDescent(), ConjugateGradient(), BFGS(), LBFGS(), NelderMead(), GradientDescent(), MomentumGradientDescent(), NelderMead(), SimulatedAnnealing(), ParticleSwarm())
+            res = optimize(f, g!, [1., 0., 1., 0.], GradientDescent())
 
-    res = optimize(f, g!, eye(2), GradientDescent())
+            @test typeof(Optim.minimizer(res)) <: Vector
+            @test vecnorm(Optim.minimizer(res) - [10.0, 0.0, 0.0, 5.0]) < 10e-8
+        end
+        # TODO: Get finite differencing to work for generic arrays as well
+        # optimize(f, eye(2), method = :gradient_descent)
+    end
 
-    @test norm(vec(Optim.minimizer(res) - [10.0 0.0; 0.0 5.0])) < 10e-8
+    @testset "matrix" begin
+        for m in (AcceleratedGradientDescent(), ConjugateGradient(), BFGS(), LBFGS(), NelderMead(), GradientDescent(), MomentumGradientDescent(), NelderMead(), SimulatedAnnealing(), ParticleSwarm())
+            res = optimize(f, g!, eye(2), GradientDescent())
 
-    # TODO: Get finite differencing to work for generic arrays as well
-    # optimize(f, eye(2), method = :gradient_descent)
+            @test typeof(Optim.minimizer(res)) <: Matrix
+            @test vecnorm(Optim.minimizer(res) - [10.0 0.0; 0.0 5.0]) < 10e-8
+        end
+        # TODO: Get finite differencing to work for generic arrays as well
+        # optimize(f, eye(2), method = :gradient_descent)
+    end
+
+    @testset "tensor" begin
+        eye3 = zeros(2,2,1)
+        eye3[:,:,1] = eye(2)
+        for m in (AcceleratedGradientDescent(), ConjugateGradient(), BFGS(), LBFGS(), NelderMead(), GradientDescent(), MomentumGradientDescent(), NelderMead(), SimulatedAnnealing(), ParticleSwarm())
+            res = optimize(f, g!, eye3, GradientDescent())
+            _minimizer = Optim.minimizer(res)
+            @test typeof(_minimizer) <: Array
+            @test size(_minimizer) == (2,2,1)
+            @test vecnorm(_minimizer - [10.0 0.0; 0.0 5.0]) < 10e-8
+        end
+        # TODO: Get finite differencing to work for generic arrays as well
+        # optimize(f, eye(2), method = :gradient_descent)
+    end
 end

--- a/test/array.jl
+++ b/test/array.jl
@@ -15,8 +15,6 @@
             @test typeof(Optim.minimizer(res)) <: Vector
             @test vecnorm(Optim.minimizer(res) - [10.0, 0.0, 0.0, 5.0]) < 10e-8
         end
-        # TODO: Get finite differencing to work for generic arrays as well
-        # optimize(f, eye(2), method = :gradient_descent)
     end
 
     @testset "matrix" begin
@@ -26,8 +24,6 @@
             @test typeof(Optim.minimizer(res)) <: Matrix
             @test vecnorm(Optim.minimizer(res) - [10.0 0.0; 0.0 5.0]) < 10e-8
         end
-        # TODO: Get finite differencing to work for generic arrays as well
-        # optimize(f, eye(2), method = :gradient_descent)
     end
 
     @testset "tensor" begin
@@ -36,11 +32,9 @@
         for m in (AcceleratedGradientDescent(), ConjugateGradient(), BFGS(), LBFGS(), NelderMead(), GradientDescent(), MomentumGradientDescent(), NelderMead(), SimulatedAnnealing(), ParticleSwarm())
             res = optimize(f, g!, eye3, GradientDescent())
             _minimizer = Optim.minimizer(res)
-            @test typeof(_minimizer) <: Array
+            @test typeof(_minimizer) <: Array{Float64, 3}
             @test size(_minimizer) == (2,2,1)
             @test vecnorm(_minimizer - [10.0 0.0; 0.0 5.0]) < 10e-8
         end
-        # TODO: Get finite differencing to work for generic arrays as well
-        # optimize(f, eye(2), method = :gradient_descent)
     end
 end


### PR DESCRIPTION
Pulled out from #337. Adds a note in the docs and tests for Vector, Matrix and `Array{T, 3}`. fixes #198 

Extra lines added are docs and tests. Most of this is just reparameterization/use of `similar`.